### PR TITLE
feat: set up Next.js frontend project structure (#23)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,7 @@
+# Stellar network configuration
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+NEXT_PUBLIC_CONTRACT_ADDRESS=
+
+# PrivacyLayer
+NEXT_PUBLIC_PRIVACY_POOL_DENOMINATIONS=XLM,USDC

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,86 @@
+# PrivacyLayer Frontend
+
+Next.js frontend for the PrivacyLayer shielded pool on Stellar Soroban.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18+ and npm
+- A Stellar wallet (e.g., [Freighter](https://freighter.app/))
+
+### Installation
+
+```bash
+cd frontend
+npm install
+```
+
+### Environment Setup
+
+```bash
+cp .env.example .env.local
+# Edit .env.local with your contract address and RPC URL
+```
+
+### Development
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+### Build
+
+```bash
+npm run build
+npm start
+```
+
+## Project Structure
+
+```
+frontend/
+├── app/                 # Next.js App Router pages
+│   ├── layout.tsx       # Root layout with nav
+│   ├── page.tsx         # Home / landing page
+│   ├── deposit/         # Deposit into shielded pool
+│   ├── withdraw/        # Withdraw with ZK proof
+│   └── history/         # Transaction history
+├── components/
+│   ├── ui/              # Reusable UI components
+│   ├── layout/          # Layout components (navbar, etc.)
+│   └── features/        # Feature-specific components
+├── lib/
+│   ├── sdk.ts           # PrivacyLayer SDK integration
+│   └── utils.ts         # Utility functions
+├── public/              # Static assets
+├── styles/
+│   └── globals.css      # Global styles + Tailwind
+├── package.json
+├── tsconfig.json
+├── tailwind.config.ts
+├── postcss.config.mjs
+└── next.config.mjs
+```
+
+## Tech Stack
+
+- **Next.js 14+** with App Router
+- **TypeScript** (strict mode)
+- **Tailwind CSS** for styling
+- **Zustand** for state management
+- **React Query** for data fetching
+- **@stellar/freighter-api** for wallet connection
+- **shadcn/ui** pattern for UI components
+
+## Scripts
+
+| Command         | Description               |
+| --------------- | ------------------------- |
+| `npm run dev`   | Start dev server          |
+| `npm run build` | Production build          |
+| `npm start`     | Start production server   |
+| `npm run lint`  | Run ESLint                |
+| `npm run format`| Format with Prettier      |

--- a/frontend/app/deposit/page.tsx
+++ b/frontend/app/deposit/page.tsx
@@ -1,0 +1,16 @@
+export default function DepositPage() {
+  return (
+    <div className="mx-auto max-w-lg">
+      <h1 className="text-3xl font-bold">Deposit</h1>
+      <p className="mt-2 text-gray-400">
+        Deposit XLM or USDC into the shielded pool.
+      </p>
+      <div className="mt-8 rounded-xl border border-gray-800 bg-gray-900/50 p-6">
+        <p className="text-sm text-gray-500">
+          Deposit form will be implemented with @stellar/freighter-api and
+          @privacylayer/sdk integration.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/history/page.tsx
+++ b/frontend/app/history/page.tsx
@@ -1,0 +1,16 @@
+export default function HistoryPage() {
+  return (
+    <div className="mx-auto max-w-2xl">
+      <h1 className="text-3xl font-bold">Transaction History</h1>
+      <p className="mt-2 text-gray-400">
+        View your shielded pool transactions.
+      </p>
+      <div className="mt-8 rounded-xl border border-gray-800 bg-gray-900/50 p-6">
+        <p className="text-sm text-gray-500">
+          Transaction history will be implemented with local note tracking and
+          on-chain event indexing.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import "@/styles/globals.css";
+
+export const metadata: Metadata = {
+  title: "PrivacyLayer — Shielded Pool on Stellar",
+  description:
+    "Compliance-forward private transactions on Stellar Soroban using zero-knowledge proofs.",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gradient-to-b from-gray-950 to-gray-900 text-white">
+        <header className="border-b border-gray-800 px-6 py-4">
+          <nav className="mx-auto flex max-w-6xl items-center justify-between">
+            <a href="/" className="text-xl font-bold tracking-tight">
+              🔐 PrivacyLayer
+            </a>
+            <div className="flex gap-6 text-sm text-gray-400">
+              <a href="/deposit" className="hover:text-white transition-colors">
+                Deposit
+              </a>
+              <a href="/withdraw" className="hover:text-white transition-colors">
+                Withdraw
+              </a>
+              <a href="/history" className="hover:text-white transition-colors">
+                History
+              </a>
+            </div>
+          </nav>
+        </header>
+        <main className="mx-auto max-w-6xl px-6 py-10">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,29 @@
+export default function HomePage() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-8 py-20 text-center">
+      <h1 className="text-5xl font-bold tracking-tight">
+        Private transactions on{" "}
+        <span className="text-stellar">Stellar</span>
+      </h1>
+      <p className="max-w-2xl text-lg text-gray-400">
+        Deposit XLM or USDC into a shielded pool, then withdraw to any address
+        using a zero-knowledge proof — with no on-chain link between deposit
+        and withdrawal.
+      </p>
+      <div className="flex gap-4">
+        <a
+          href="/deposit"
+          className="rounded-lg bg-primary-600 px-6 py-3 font-medium transition-colors hover:bg-primary-700"
+        >
+          Deposit
+        </a>
+        <a
+          href="/withdraw"
+          className="rounded-lg border border-gray-700 px-6 py-3 font-medium transition-colors hover:border-gray-500"
+        >
+          Withdraw
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/withdraw/page.tsx
+++ b/frontend/app/withdraw/page.tsx
@@ -1,0 +1,16 @@
+export default function WithdrawPage() {
+  return (
+    <div className="mx-auto max-w-lg">
+      <h1 className="text-3xl font-bold">Withdraw</h1>
+      <p className="mt-2 text-gray-400">
+        Withdraw from the shielded pool using a ZK proof.
+      </p>
+      <div className="mt-8 rounded-xl border border-gray-800 bg-gray-900/50 p-6">
+        <p className="text-sm text-gray-500">
+          Withdraw form will be implemented with ZK proof generation and
+          Soroban contract interaction.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/features/index.ts
+++ b/frontend/components/features/index.ts
@@ -1,0 +1,2 @@
+// Feature components will be added as functionality is implemented.
+export {};

--- a/frontend/components/layout/index.ts
+++ b/frontend/components/layout/index.ts
@@ -1,0 +1,1 @@
+export { Navbar } from "./navbar";

--- a/frontend/components/layout/navbar.tsx
+++ b/frontend/components/layout/navbar.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+
+export function Navbar() {
+  const [connected, setConnected] = useState(false);
+
+  return (
+    <header className="border-b border-gray-800 px-6 py-4">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between">
+        <a href="/" className="text-xl font-bold tracking-tight">
+          🔐 PrivacyLayer
+        </a>
+        <div className="flex items-center gap-6">
+          <div className="flex gap-6 text-sm text-gray-400">
+            <a href="/deposit" className="hover:text-white transition-colors">
+              Deposit
+            </a>
+            <a href="/withdraw" className="hover:text-white transition-colors">
+              Withdraw
+            </a>
+            <a href="/history" className="hover:text-white transition-colors">
+              History
+            </a>
+          </div>
+          <button
+            onClick={() => setConnected(!connected)}
+            className="rounded-lg border border-gray-700 px-4 py-2 text-sm transition-colors hover:border-stellar"
+          >
+            {connected ? "Connected" : "Connect Wallet"}
+          </button>
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/lib/utils";
+import { ButtonHTMLAttributes, forwardRef } from "react";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "default" | "outline" | "ghost";
+  size?: "sm" | "md" | "lg";
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", size = "md", ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "inline-flex items-center justify-center rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:pointer-events-none disabled:opacity-50",
+          {
+            "bg-primary-600 text-white hover:bg-primary-700":
+              variant === "default",
+            "border border-gray-700 hover:border-gray-500":
+              variant === "outline",
+            "hover:bg-gray-800": variant === "ghost",
+          },
+          {
+            "h-8 px-3 text-sm": size === "sm",
+            "h-10 px-4 text-sm": size === "md",
+            "h-12 px-6 text-base": size === "lg",
+          },
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Button.displayName = "Button";
+export { Button };

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -1,0 +1,2 @@
+export { Button } from "./button";
+export type { ButtonProps } from "./button";

--- a/frontend/lib/sdk.ts
+++ b/frontend/lib/sdk.ts
@@ -1,0 +1,26 @@
+/**
+ * PrivacyLayer SDK integration stub.
+ *
+ * This module will wrap @privacylayer/sdk when it becomes available,
+ * providing typed helpers for deposit, withdraw, and nullifier operations.
+ */
+
+export interface DepositParams {
+  asset: "XLM" | "USDC";
+  amount: string;
+}
+
+export interface WithdrawParams {
+  note: string;
+  recipient: string;
+}
+
+export async function deposit(_params: DepositParams): Promise<string> {
+  // TODO: integrate with @privacylayer/sdk
+  throw new Error("SDK not yet available");
+}
+
+export async function withdraw(_params: WithdrawParams): Promise<string> {
+  // TODO: integrate with @privacylayer/sdk
+  throw new Error("SDK not yet available");
+}

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "privacylayer-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "format": "prettier --write \"**/*.{ts,tsx,md,json}\""
+  },
+  "dependencies": {
+    "@stellar/freighter-api": "^2.0.0",
+    "next": "^14.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "zustand": "^4.5.0",
+    "@tanstack/react-query": "^5.40.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "tailwind-merge": "^2.3.0",
+    "lucide-react": "^0.390.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.4.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.0",
+    "prettier": "^3.3.0"
+  }
+}

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+  }
+
+  :root[class~="dark"] {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+  }
+
+  body {
+    @apply bg-white text-gray-900 antialiased;
+  }
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,39 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: "#7C3AED",
+          50: "#F5F3FF",
+          100: "#EDE9FE",
+          200: "#DDD6FE",
+          300: "#C4B5FD",
+          400: "#A78BFA",
+          500: "#8B5CF6",
+          600: "#7C3AED",
+          700: "#6D28D9",
+          800: "#5B21B6",
+          900: "#4C1D95",
+        },
+        stellar: {
+          DEFAULT: "#14B8E6",
+          dark: "#0E7DA8",
+        },
+      },
+      fontFamily: {
+        sans: ["Inter", "system-ui", "sans-serif"],
+        mono: ["JetBrains Mono", "monospace"],
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Implements the Next.js frontend project structure as specified in #23.

### What's included

- **Next.js 14+ with App Router** and TypeScript (strict mode)
- **Tailwind CSS** with custom theme colors (Stellar blue, purple primary)
- **Project structure** as specified in the issue:
  ```
  frontend/
  ├── app/                 # Pages: home, deposit, withdraw, history
  ├── components/
  │   ├── ui/              # Reusable UI (Button component)
  │   ├── layout/          # Navbar with wallet connect stub
  │   └── features/        # Ready for feature components
  ├── lib/
  │   ├── sdk.ts           # PrivacyLayer SDK integration stub
  │   └── utils.ts         # cn() utility (clsx + tailwind-merge)
  ├── public/
  ├── styles/globals.css
  └── Config files (tsconfig, tailwind, eslint, prettier, etc.)
  ```

### Dependencies included
- `@stellar/freighter-api` — wallet connection
- `zustand` — state management
- `@tanstack/react-query` — data fetching
- `class-variance-authority` + `clsx` + `tailwind-merge` — shadcn/ui pattern
- `lucide-react` — icons

### Acceptance criteria
- [x] Next.js project initialized
- [x] TypeScript configured (strict mode)
- [x] Tailwind CSS working
- [x] Basic routing set up (4 pages)
- [x] `npm run dev` starts dev server
- [x] `npm run build` builds successfully
- [x] README with setup instructions

### Environment
- `.env.example` provided with Stellar network config vars

Closes #23