### PR TITLE
feat: add comprehensive edge cases tests for all circuits

### DIFF
--- a/circuits/Nargo.toml
+++ b/circuits/Nargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "commitment",
+    "lib",
     "merkle",
     "withdraw",
 ]

--- a/circuits/TEST_VECTORS.md
+++ b/circuits/TEST_VECTORS.md
@@ -1,0 +1,175 @@
+# PrivacyLayer Circuit Test Vectors
+
+Documentation of all test cases across the three Noir circuits.  
+Run tests with: `cd circuits && nargo test`
+
+---
+
+## Overview
+
+| Circuit | File | Tests |
+|---|---|---|
+| Commitment | `commitment/src/main.nr` | 16 |
+| Withdrawal | `withdraw/src/main.nr` | 21 |
+| Merkle Library | `merkle/src/lib.nr` | 12 |
+| Test Helpers | `lib/src/validation/test_helpers.nr` | 4 |
+| **Total** | | **53** |
+
+---
+
+## Commitment Circuit Tests (`commitment/src/main.nr`)
+
+### Happy Path
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-C-01 | `test_valid_commitment` | Small field values (nullifier=1, secret=2) | PASS |
+| TC-C-02 | `test_valid_commitment_large_values` | Hex-encoded values (100, 1000) | PASS |
+| TC-C-03 | `test_valid_commitment_near_max_field` | Values near BN254 field limit (2^253) | PASS |
+| TC-C-04 | `test_commitment_is_deterministic` | Same inputs called twice yield equal commitment | PASS |
+
+### Zero / Boundary Values
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-C-05 | `test_zero_inputs_valid_commitment` | nullifier=0, secret=0 → H(0,0) is valid | PASS |
+| TC-C-06 | `test_zero_nullifier_nonzero_secret` | nullifier=0, secret=12345 | PASS |
+| TC-C-07 | `test_nonzero_nullifier_zero_secret` | nullifier=99999, secret=0 | PASS |
+| TC-C-08 | `test_identical_nullifier_and_secret` | nullifier == secret == 7777 | PASS |
+
+### Collision / Uniqueness
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-C-09 | `test_no_commitment_collision_different_inputs` | H(1,2) ≠ H(3,4) | PASS (distinct outputs) |
+| TC-C-10 | `test_commitment_is_not_symmetric` | H(10,20) ≠ H(20,10) | PASS (non-symmetric) |
+| TC-C-11 | `test_adjacent_nullifiers_produce_distinct_commitments` | H(1,k) ≠ H(2,k) | PASS (distinct) |
+
+### Attack / Failure Cases
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-C-12 | `test_wrong_nullifier_fails` | Wrong nullifier, real commitment | FAIL: "commitment mismatch" |
+| TC-C-13 | `test_wrong_secret_fails` | Wrong secret, real commitment | FAIL: "commitment mismatch" |
+| TC-C-14 | `test_swapped_inputs_fails` | (secret, nullifier) — swapped order | FAIL: "commitment mismatch" |
+| TC-C-15 | `test_zero_inputs_with_fabricated_commitment_fails` | nullifier=0, secret=0, commitment=12345 | FAIL: "commitment mismatch" |
+| TC-C-16 | `test_off_by_one_commitment_fails` | Real commitment + 1 | FAIL: "commitment mismatch" |
+
+---
+
+## Withdrawal Circuit Tests (`withdraw/src/main.nr`)
+
+### Happy Path
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-W-01 | `test_valid_withdrawal` | Standard withdrawal, no relayer | PASS |
+| TC-W-02 | `test_withdrawal_with_relayer_fee` | Relayer with 1 XLM fee | PASS |
+| TC-W-03 | `test_withdrawal_fee_equals_amount` | fee == amount (max legal fee) | PASS |
+| TC-W-04 | `test_withdrawal_nonzero_leaf_index` | Leaf at index=7 (binary 0b0111) | PASS |
+
+### Merkle / Inclusion Tests
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-W-05 | `test_wrong_secret_fails` | Wrong secret changes commitment → Merkle fails | FAIL: "leaf not in tree" |
+| TC-W-06 | `test_wrong_root_fails` | Fabricated root, valid path | FAIL: "leaf not in tree" |
+| TC-W-07 | `test_wrong_leaf_index_fails` | Path for index=0 but claim index=1 | FAIL: "leaf not in tree" |
+| TC-W-08 | `test_tampered_auth_path_fails` | Level-3 sibling overwritten | FAIL: "leaf not in tree" |
+| TC-W-09 | `test_zero_commitment_valid_if_in_tree` | H(0,0) is a leaf; circuit accepts it | PASS |
+| TC-W-10 | `test_max_leaf_index` | Index = 2^20 - 1 (all bits set, depth 20) | PASS |
+
+### Nullifier Hash Tests
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-W-11 | `test_wrong_nullifier_hash_fails` | Fabricated nullifier_hash (54321) | FAIL: "nullifier_hash mismatch" |
+| TC-W-12 | `test_nullifier_hash_from_different_nullifier_fails` | Hash derived from nullifier=9999 | FAIL: "nullifier_hash mismatch" |
+| TC-W-13 | `test_nullifier_hash_bound_to_root` | Cross-root replay — stale root in nullifier_hash | FAIL: "nullifier_hash mismatch" |
+| TC-W-14 | `test_zero_nullifier_hash_fails` | Attacker submits nullifier_hash=0 | FAIL: "nullifier_hash mismatch" |
+
+### Fee / Relayer Validation
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-W-15 | `test_fee_exceeds_amount_fails` | fee=100 > amount=10 | FAIL: "fee cannot exceed withdrawal amount" |
+| TC-W-16 | `test_nonzero_relayer_with_zero_fee_fails` | relayer≠0, fee=0 | FAIL: "relayer must be zero address if fee is zero" |
+| TC-W-17 | `test_zero_fee_zero_relayer_valid` | No relayer, no fee | PASS |
+| TC-W-18 | `test_unit_amount_unit_fee_valid` | amount=1, fee=1 (min boundary) | PASS |
+
+### Boundary / Miscellaneous
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-W-19 | `test_withdrawal_large_field_values` | Witnesses near BN254 field limit | PASS |
+| TC-W-20 | `test_two_notes_same_root_both_valid` | Two notes at index 0 and 1, shared root | PASS |
+| TC-W-21 | `test_nullifier_hash_differs_across_roots` | Same nullifier, different roots → different hashes | PASS (distinct) |
+
+---
+
+## Merkle Library Tests (`merkle/src/lib.nr`)
+
+### Root Computation
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-M-01 | `test_single_leaf_tree` | Leaf=42 at index=0, manually verified root hash chain | PASS |
+| TC-M-02 | `test_nonempty_leaf_produces_nonzero_root` | Leaf=12345, all-zero path → root ≠ 0 | PASS |
+| TC-M-03 | `test_right_child_position` | Index=1 → H(sibling, leaf) at level 0 | PASS |
+| TC-M-04 | `test_same_leaf_same_root` | Determinism check with non-trivial path | PASS |
+| TC-M-05 | `test_max_index_root_computable` | Index = 1048575 (all 20 bits set) | PASS |
+
+### Inclusion Verification
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-M-06 | `test_verify_inclusion_correct_root` | Round-trip: compute root then verify | PASS |
+| TC-M-07 | `test_verify_inclusion_wrong_root_fails` | Wrong root (9999) | FAIL: "leaf not in tree" |
+| TC-M-08 | `test_verify_inclusion_wrong_index_fails` | Root for index=0 claimed at index=1 | FAIL: "leaf not in tree" |
+| TC-M-09 | `test_verify_inclusion_tampered_sibling_fails` | Level-5 sibling overwritten | FAIL: "leaf not in tree" |
+
+### Hash Consistency
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-M-10 | `test_left_vs_right_child_produce_different_roots` | Same leaf at index=0 vs index=1 | PASS (distinct roots) |
+| TC-M-11 | `test_sibling_leaf_swap_changes_root` | Leaf_A sibling=Leaf_B vs Leaf_B sibling=Leaf_A | PASS (distinct roots) |
+| TC-M-12 | `test_zero_leaf_nonzero_path` | Leaf=0, non-zero path → root≠0, verify_inclusion passes | PASS |
+
+---
+
+## Test Helper Vectors (`lib/src/validation/test_helpers.nr`)
+
+### Canonical KAT Values
+
+| Symbol | Value | Description |
+|---|---|---|
+| `KAT_NULLIFIER` | `1` | Default nullifier for fixture generation |
+| `KAT_SECRET` | `2` | Default secret for fixture generation |
+| `KAT_LEAF_INDEX` | `0` | Default leaf position |
+| `KAT_AMOUNT` | `100_0000000` | 100 XLM in stroops |
+| `KAT_RECIPIENT` | `0xABCD` | Canonical recipient field value |
+
+### Helper Self-Tests
+
+| ID | Test Name | Scenario | Expected |
+|---|---|---|---|
+| TC-H-01 | `test_build_valid_fixture_is_consistent` | Fixture root and nullifier_hash are self-consistent | PASS |
+| TC-H-02 | `test_build_two_leaf_tree_shared_root` | Both leaves produce the same root | PASS |
+| TC-H-03 | `test_tamper_path_changes_root` | Tampered sibling at level 3 changes root | PASS |
+| TC-H-04 | `test_build_fixture_at_high_index` | Fixture at index=524288 (bit 19 only) is consistent | PASS |
+
+---
+
+## References
+
+- [Tornado Cash test vectors](https://github.com/tornadocash/tornado-core/tree/master/test)
+- [Penumbra TCT specification](https://protocol.penumbra.zone/main/crypto/tct.html)
+- [Noir standard library test patterns](https://github.com/noir-lang/noir-examples)
+- [BN254 scalar field](https://hackmd.io/@jpw/bn254) — prime r ≈ 2^254
+
+---
+
+> **Coverage target**: ≥ 90% of circuit branches exercised.  
+> **Hash implementation**: Pedersen (BN254) via `std::hash::pedersen_hash`.  
+> **Tree depth**: 20 levels — supports up to 2^20 = 1,048,576 notes.

--- a/circuits/commitment/src/main.nr
+++ b/circuits/commitment/src/main.nr
@@ -41,7 +41,19 @@ fn main(
 // ============================================================
 // Tests - following noir-lang/noir-examples test patterns
 // ============================================================
+// Total tests: 16
+//   - Happy path tests (4)
+//   - Zero / boundary tests (4)
+//   - Collision / uniqueness tests (3)
+//   - Attack / failure tests (5)
+// ============================================================
 
+// ------------------------------------------------------------
+// Happy Path Tests
+// ------------------------------------------------------------
+
+/// TC-C-01: Basic valid commitment with small field values.
+/// Verifies the circuit accepts correctly-formed proofs.
 #[test]
 fn test_valid_commitment() {
     // Known values: commitment = Hash(nullifier=1, secret=2)
@@ -53,57 +65,185 @@ fn test_valid_commitment() {
     main(nullifier, secret, commitment);
 }
 
+/// TC-C-02: Valid commitment with large hex-encoded field elements
+/// (simulates realistic SDK-generated random values near field size).
 #[test]
 fn test_valid_commitment_large_values() {
-    // Test with large field elements (near BN254 field prime)
     let nullifier: Field = 0x0000000000000000000000000000000000000000000000000000000000000064; // 100
-    let secret: Field = 0x00000000000000000000000000000000000000000000000000000000000003e8; // 1000
+    let secret: Field    = 0x00000000000000000000000000000000000000000000000000000000000003e8; // 1000
     let commitment = hash::compute_commitment(nullifier, secret);
 
     main(nullifier, secret, commitment);
 }
 
+/// TC-C-03: Valid commitment with maximum safe field value.
+/// BN254 scalar field modulus r = 2^254 - ... This uses a value that is
+/// valid within the field. The circuit must handle high-valued witnesses.
+#[test]
+fn test_valid_commitment_near_max_field() {
+    // A large prime-like field element near (but within) the BN254 scalar field.
+    // BN254 r ~ 2^254, so 2^253 is safely inside the field.
+    let nullifier: Field = 0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    let secret: Field    = 0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    main(nullifier, secret, commitment);
+}
+
+/// TC-C-04: Determinism -- same inputs always yield the exact same commitment.
+/// Essential for note reconstruction and proof generation.
+#[test]
+fn test_commitment_is_deterministic() {
+    let nullifier: Field = 0xdeadbeef;
+    let secret: Field    = 0xcafebabe;
+
+    let c1 = hash::compute_commitment(nullifier, secret);
+    let c2 = hash::compute_commitment(nullifier, secret);
+
+    // If commitments are equal, the circuit accepts both
+    assert(c1 == c2, "commitment must be deterministic");
+    main(nullifier, secret, c1);
+}
+
+// ------------------------------------------------------------
+// Zero / Boundary Value Tests
+// ------------------------------------------------------------
+
+/// TC-C-05: Zero nullifier with zero secret -- edge case where both
+/// inputs are the additive identity. The circuit must compute and
+/// accept H(0, 0) as a valid commitment (not special-cased to fail).
+#[test]
+fn test_zero_inputs_valid_commitment() {
+    let nullifier: Field = 0;
+    let secret: Field    = 0;
+    let commitment = hash::compute_commitment(nullifier, secret);
+    main(nullifier, secret, commitment);
+}
+
+/// TC-C-06: Zero nullifier -- only the secret is non-zero.
+/// Verifies partial-zero inputs are handled correctly.
+#[test]
+fn test_zero_nullifier_nonzero_secret() {
+    let nullifier: Field = 0;
+    let secret: Field    = 12345;
+    let commitment = hash::compute_commitment(nullifier, secret);
+    main(nullifier, secret, commitment);
+}
+
+/// TC-C-07: Non-zero nullifier with zero secret.
+/// Mirror of TC-C-06 for the other input.
+#[test]
+fn test_nonzero_nullifier_zero_secret() {
+    let nullifier: Field = 99999;
+    let secret: Field    = 0;
+    let commitment = hash::compute_commitment(nullifier, secret);
+    main(nullifier, secret, commitment);
+}
+
+/// TC-C-08: nullifier == secret (identical inputs).
+/// The hash function ought to distinguish this from other cases;
+/// the circuit accepts it as long as the commitment is correct.
+#[test]
+fn test_identical_nullifier_and_secret() {
+    let nullifier: Field = 7777;
+    let secret: Field    = 7777;
+    let commitment = hash::compute_commitment(nullifier, secret);
+    main(nullifier, secret, commitment);
+}
+
+// ------------------------------------------------------------
+// Collision / Uniqueness Tests
+// ------------------------------------------------------------
+
+/// TC-C-09: Different notes must produce different commitments (collision resistance).
+/// A collision would allow two depositors to share a single on-chain slot.
+#[test]
+fn test_no_commitment_collision_different_inputs() {
+    let c1 = hash::compute_commitment(1, 2);
+    let c2 = hash::compute_commitment(3, 4);
+    assert(c1 != c2, "different (nullifier, secret) pairs must not collide");
+}
+
+/// TC-C-10: Verify the hash is NOT symmetric, i.e. H(a,b) != H(b,a).
+/// If it were symmetric, swapped inputs would open any note.
+#[test]
+fn test_commitment_is_not_symmetric() {
+    let a: Field = 10;
+    let b: Field = 20;
+    let c_ab = hash::compute_commitment(a, b);
+    let c_ba = hash::compute_commitment(b, a);
+    // For a correctly ordered hash we expect c_ab != c_ba.
+    // If Pedersen is symmetric for this case this assertion would fail, exposing the bug.
+    assert(c_ab != c_ba, "H(a,b) must differ from H(b,a) – hash must be non-symmetric");
+}
+
+/// TC-C-11: Verifying that incrementing nullifier by 1 changes the commitment.
+/// Ensures small deltas are visible (no partial-preimage attack surface).
+#[test]
+fn test_adjacent_nullifiers_produce_distinct_commitments() {
+    let secret: Field = 100;
+    let c1 = hash::compute_commitment(1, secret);
+    let c2 = hash::compute_commitment(2, secret);
+    assert(c1 != c2, "adjacent nullifiers must produce different commitments");
+}
+
+// ------------------------------------------------------------
+// Attack / Failure Tests
+// ------------------------------------------------------------
+
+/// TC-C-12: Wrong nullifier with correct secret and real commitment -- must fail.
+/// Simulates an adversary who knows the secret but not the nullifier.
 #[test(should_fail_with = "commitment mismatch: invalid nullifier/secret pair")]
 fn test_wrong_nullifier_fails() {
     let nullifier: Field = 1;
-    let secret: Field = 2;
+    let secret: Field    = 2;
     let commitment = hash::compute_commitment(nullifier, secret);
 
     // Provide wrong nullifier - should fail the assertion
     main(999, secret, commitment);
 }
 
+/// TC-C-13: Wrong secret with correct nullifier and real commitment -- must fail.
+/// Simulates an adversary who knows the nullifier but not the secret.
 #[test(should_fail_with = "commitment mismatch: invalid nullifier/secret pair")]
 fn test_wrong_secret_fails() {
     let nullifier: Field = 1;
-    let secret: Field = 2;
+    let secret: Field    = 2;
     let commitment = hash::compute_commitment(nullifier, secret);
 
     // Provide wrong secret - should fail the assertion
     main(nullifier, 888, commitment);
 }
 
+/// TC-C-14: Swapped nullifier / secret -- must fail.
+/// Even when both values are known, order matters in H(nullifier, secret).
 #[test(should_fail_with = "commitment mismatch: invalid nullifier/secret pair")]
 fn test_swapped_inputs_fails() {
     let nullifier: Field = 1;
-    let secret: Field = 2;
+    let secret: Field    = 2;
     let commitment = hash::compute_commitment(nullifier, secret);
 
     // Swap nullifier and secret - should fail (hash is not symmetric)
     main(secret, nullifier, commitment);
 }
 
+/// TC-C-15: Fabricated (random) commitment value with zero inputs -- must fail.
+/// An attacker who cannot compute the preimage should never be able to pass
+/// a random commitment through the circuit.
 #[test(should_fail_with = "commitment mismatch: invalid nullifier/secret pair")]
-fn test_zero_inputs_with_wrong_commitment() {
+fn test_zero_inputs_with_fabricated_commitment_fails() {
     // Both zero with fabricated commitment value - should fail
     main(0, 0, 12345);
 }
 
-#[test]
-fn test_zero_inputs_valid_commitment() {
-    // Zero inputs should still work if commitment is correct
-    let nullifier: Field = 0;
-    let secret: Field = 0;
-    let commitment = hash::compute_commitment(nullifier, secret);
-    main(nullifier, secret, commitment);
+/// TC-C-16: Off-by-one commitment -- commitment is H(nullifier, secret) + 1.
+/// Ensures the constraint rejects values that are only slightly wrong.
+#[test(should_fail_with = "commitment mismatch: invalid nullifier/secret pair")]
+fn test_off_by_one_commitment_fails() {
+    let nullifier: Field = 42;
+    let secret: Field    = 43;
+    let real_commitment = hash::compute_commitment(nullifier, secret);
+    // Add 1 to produce an off-by-one value (will wrap in the field -- still wrong)
+    let tampered: Field = real_commitment + 1;
+    main(nullifier, secret, tampered);
 }

--- a/circuits/lib/src/merkle/mod.nr
+++ b/circuits/lib/src/merkle/mod.nr
@@ -35,13 +35,13 @@ pub fn compute_root(
 ) -> Field {
     // Decompose index into bits to determine left/right at each level
     // Bit 0 = deepest level (leaf level), bit 19 = root level
-    let index_bits: [u1; 20] = index.to_le_bits();
+    let index_bits: [bool; 20] = index.to_le_bits();
 
     let mut current = leaf;
 
     for i in 0..20 {
         // At level i: if bit i is 0, current is left child; if 1, it's right child
-        let is_right = index_bits[i] != 0;
+        let is_right = index_bits[i];
 
         let left  = if is_right { hash_path[i] } else { current };
         let right = if is_right { current } else { hash_path[i] };

--- a/circuits/lib/src/validation/mod.nr
+++ b/circuits/lib/src/validation/mod.nr
@@ -26,3 +26,6 @@ pub fn validate_commitment(computed: Field, expected: Field) {
 pub fn validate_nullifier_hash(computed: Field, expected: Field) {
     assert(computed == expected, "nullifier_hash mismatch: invalid nullifier or wrong root");
 }
+
+// Test helper utilities (shared across all circuit test suites)
+pub mod test_helpers;

--- a/circuits/lib/src/validation/test_helpers.nr
+++ b/circuits/lib/src/validation/test_helpers.nr
@@ -1,0 +1,187 @@
+// ============================================================
+// PrivacyLayer - Test Helper Utilities
+// ============================================================
+// Reusable fixtures, known-answer test vectors, and utility
+// functions shared across all circuit test suites.
+//
+// Usage:
+//   use lib::validation::test_helpers;
+//
+// Conventions:
+//   - VALID_*  : known-good vectors that any circuit must accept
+//   - INVALID_* : known-bad vectors that circuits must reject
+//   - build_*   : functions that construct test inputs dynamically
+// ============================================================
+
+use crate::hash;
+use crate::merkle;
+
+// ============================================================
+// Known-Answer Test (KAT) Vectors
+// ============================================================
+// These are pre-computed reference values pinned to the
+// Pedersen hash implementation in hash/mod.nr.
+// If the hash implementation changes, recompute these.
+// ============================================================
+
+/// Canonical test nullifier (small field value, easy to debug).
+pub global KAT_NULLIFIER: Field = 1;
+/// Canonical test secret.
+pub global KAT_SECRET: Field = 2;
+/// Canonical leaf index for KAT proofs.
+pub global KAT_LEAF_INDEX: Field = 0;
+/// Standard withdrawal amount: 100 XLM in stroops.
+pub global KAT_AMOUNT: Field = 100_0000000;
+/// Canonical recipient field value.
+pub global KAT_RECIPIENT: Field = 0xABCD;
+
+// ============================================================
+// Fixture Builder Functions
+// ============================================================
+
+/// Build a complete, valid withdrawal proof fixture for leaf at index 0.
+///
+/// Returns (nullifier, secret, leaf_index, hash_path, root, nullifier_hash)
+/// for use in withdrawal circuit tests.
+///
+/// Example:
+/// ```noir
+/// let f = test_helpers::build_valid_fixture();
+/// main(f.0, f.1, f.2, f.3, f.4, f.5, recipient, amount, 0, 0);
+/// ```
+pub fn build_valid_fixture() -> (Field, Field, Field, [Field; 20], Field, Field) {
+    let nullifier: Field = KAT_NULLIFIER;
+    let secret: Field    = KAT_SECRET;
+    let commitment = hash::compute_commitment(nullifier, secret);
+    let leaf_index: Field = KAT_LEAF_INDEX;
+
+    let hash_path: [Field; 20] = [0; 20];
+    let root = merkle::compute_root(commitment, leaf_index, hash_path);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    (nullifier, secret, leaf_index, hash_path, root, nullifier_hash)
+}
+
+/// Build a withdrawal fixture for a leaf at an arbitrary index.
+///
+/// Useful for testing index decomposition edge cases.
+pub fn build_fixture_at_index(
+    nullifier: Field,
+    secret: Field,
+    leaf_index: Field,
+) -> ([Field; 20], Field, Field) {
+    let commitment = hash::compute_commitment(nullifier, secret);
+    let hash_path: [Field; 20] = [0; 20];
+    let root = merkle::compute_root(commitment, leaf_index, hash_path);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+    (hash_path, root, nullifier_hash)
+}
+
+/// Build a two-leaf tree and return paths/root for both leaves.
+///
+/// Returns (path1, path2, shared_root).
+/// Leaf 1 is at index 0 with commitment c1; leaf 2 is at index 1 with commitment c2.
+pub fn build_two_leaf_tree(c1: Field, c2: Field) -> ([Field; 20], [Field; 20], Field) {
+    let mut path1: [Field; 20] = [0; 20];
+    path1[0] = c2; // sibling of c1 at level 0 is c2
+
+    let mut path2: [Field; 20] = [0; 20];
+    path2[0] = c1; // sibling of c2 at level 0 is c1
+
+    let root = merkle::compute_root(c1, 0, path1);
+    (path1, path2, root)
+}
+
+/// Corrupt a Merkle path by overwriting one sibling with a garbage value.
+/// `level` must be in range [0, 19].
+pub fn tamper_path(path: [Field; 20], level: Field) -> [Field; 20] {
+    let mut bad_path = path;
+    // Use a field constant as the garbage value
+    if level == 0 { bad_path[0] = 0xDEADBEEF; }
+    else if level == 1 { bad_path[1] = 0xDEADBEEF; }
+    else if level == 2 { bad_path[2] = 0xDEADBEEF; }
+    else if level == 3 { bad_path[3] = 0xDEADBEEF; }
+    else if level == 4 { bad_path[4] = 0xDEADBEEF; }
+    else if level == 5 { bad_path[5] = 0xDEADBEEF; }
+    else if level == 6 { bad_path[6] = 0xDEADBEEF; }
+    else if level == 7 { bad_path[7] = 0xDEADBEEF; }
+    else if level == 8 { bad_path[8] = 0xDEADBEEF; }
+    else if level == 9 { bad_path[9] = 0xDEADBEEF; }
+    else if level == 10 { bad_path[10] = 0xDEADBEEF; }
+    else if level == 11 { bad_path[11] = 0xDEADBEEF; }
+    else if level == 12 { bad_path[12] = 0xDEADBEEF; }
+    else if level == 13 { bad_path[13] = 0xDEADBEEF; }
+    else if level == 14 { bad_path[14] = 0xDEADBEEF; }
+    else if level == 15 { bad_path[15] = 0xDEADBEEF; }
+    else if level == 16 { bad_path[16] = 0xDEADBEEF; }
+    else if level == 17 { bad_path[17] = 0xDEADBEEF; }
+    else if level == 18 { bad_path[18] = 0xDEADBEEF; }
+    else { bad_path[19] = 0xDEADBEEF; }
+    bad_path
+}
+
+// ============================================================
+// Self-Tests for the Test Helper Module
+// ============================================================
+
+/// TC-H-01: build_valid_fixture produces a logically consistent fixture.
+/// Commitment re-derived from nullifier/secret must match the tree leaf.
+#[test]
+fn test_build_valid_fixture_is_consistent() {
+    let (nullifier, secret, leaf_index, hash_path, root, nullifier_hash) = build_valid_fixture();
+
+    // Re-derive all values and verify consistency
+    let commitment = hash::compute_commitment(nullifier, secret);
+    let recomputed_root = merkle::compute_root(commitment, leaf_index, hash_path);
+    let recomputed_nh   = hash::compute_nullifier_hash(nullifier, root);
+
+    assert(recomputed_root == root, "fixture root must match recomputed root");
+    assert(recomputed_nh  == nullifier_hash, "fixture nullifier_hash must match recomputed value");
+}
+
+/// TC-H-02: build_two_leaf_tree -- both leaves share the same root.
+#[test]
+fn test_build_two_leaf_tree_shared_root() {
+    let c1: Field = 0x1111;
+    let c2: Field = 0x2222;
+
+    let (path1, path2, root) = build_two_leaf_tree(c1, c2);
+
+    let root_from_c1 = merkle::compute_root(c1, 0, path1);
+    let root_from_c2 = merkle::compute_root(c2, 1, path2);
+
+    assert(root_from_c1 == root, "c1 path must yield the same root");
+    assert(root_from_c2 == root, "c2 path must yield the same root");
+}
+
+/// TC-H-03: tamper_path -- tampering corrupts the root.
+#[test]
+fn test_tamper_path_changes_root() {
+    let leaf: Field  = 42;
+    let index: Field = 0;
+    let hash_path: [Field; 20] = [0; 20];
+
+    let honest_root  = merkle::compute_root(leaf, index, hash_path);
+    let bad_path     = tamper_path(hash_path, 3);
+    let tampered_root = merkle::compute_root(leaf, index, bad_path);
+
+    assert(honest_root != tampered_root, "tampered path must change the root");
+}
+
+/// TC-H-04: build_fixture_at_index with leaf_index=19 (high-bit set only).
+#[test]
+fn test_build_fixture_at_high_index() {
+    let nullifier: Field = 0x5555;
+    let secret: Field    = 0x6666;
+    let leaf_index: Field = 524288; // bit 19 only: 0b10...0
+
+    let (hash_path, root, nullifier_hash) = build_fixture_at_index(nullifier, secret, leaf_index);
+
+    // Verify consistency
+    let commitment = hash::compute_commitment(nullifier, secret);
+    let recomputed_root = merkle::compute_root(commitment, leaf_index, hash_path);
+    let recomputed_nh   = hash::compute_nullifier_hash(nullifier, root);
+
+    assert(recomputed_root == root);
+    assert(recomputed_nh   == nullifier_hash);
+}

--- a/circuits/merkle/src/lib.nr
+++ b/circuits/merkle/src/lib.nr
@@ -14,7 +14,20 @@ pub use lib::merkle::{compute_root, verify_inclusion, TREE_DEPTH};
 // ============================================================
 // Tests
 // ============================================================
+// Total tests: 12
+//   - Root computation tests    (5)
+//   - Inclusion verification    (4)
+//   - Hash consistency tests    (2)
+//   - Tree position tests       (1)
+// ============================================================
 
+// ------------------------------------------------------------
+// Root Computation Tests
+// ------------------------------------------------------------
+
+/// TC-M-01: Single-leaf logical tree -- verify root is deterministically
+/// computed from one leaf and an all-zero sibling hash-path.
+/// The computed root must be non-zero (a non-zero leaf always yields non-zero root).
 #[test]
 fn test_single_leaf_tree() {
     // Depth-1 tree (simplified): just verify the hash composition
@@ -37,6 +50,18 @@ fn test_single_leaf_tree() {
     assert(computed == expected);
 }
 
+/// TC-M-02: Root of non-zero leaf with all-zero siblings is itself non-zero.
+/// Ensures the hash chain doesn't accidentally collapse.
+#[test]
+fn test_nonempty_leaf_produces_nonzero_root() {
+    let leaf: Field = 12345;
+    let hash_path: [Field; 20] = [0; 20];
+    let root = merkle::compute_root(leaf, 0, hash_path);
+    assert(root != 0, "root with a non-zero leaf must not be zero");
+}
+
+/// TC-M-03: Right child position (index=1 -> bit-0 = 1).
+/// H(sibling, leaf) is used at level 0, not H(leaf, sibling).
 #[test]
 fn test_right_child_position() {
     // Leaf at index=1 means it's the RIGHT child at level 0
@@ -57,6 +82,8 @@ fn test_right_child_position() {
     assert(computed == expected);
 }
 
+/// TC-M-04: Determinism -- same (leaf, index, path) always yields the same root.
+/// Critical property: provers cannot produce differing roots for the same inputs.
 #[test]
 fn test_same_leaf_same_root() {
     // Same inputs must always produce the same root (determinism)
@@ -69,16 +96,25 @@ fn test_same_leaf_same_root() {
     assert(root1 == root2);
 }
 
-#[test(should_fail_with = "merkle inclusion check failed: leaf not in tree")]
-fn test_verify_inclusion_wrong_root_fails() {
-    let leaf: Field = 42;
-    let index: Field = 0;
+/// TC-M-05: Full 20-bit index (2^20 - 1 = 1048575 -- rightmost leaf).
+/// Tests that the bit decomposition at full depth does not overflow or panic.
+#[test]
+fn test_max_index_root_computable() {
+    let leaf: Field = 0xABCDEF;
+    let index: Field = 1048575; // all 20 bits set
     let hash_path: [Field; 20] = [0; 20];
-    let wrong_root: Field = 9999; // not the real root
 
-    merkle::verify_inclusion(leaf, index, hash_path, wrong_root);
+    let root = merkle::compute_root(leaf, index, hash_path);
+    // Root must differ from the root at index 0
+    let root_at_zero = merkle::compute_root(leaf, 0, hash_path);
+    assert(root != root_at_zero, "max-index root must differ from index-0 root");
 }
 
+// ------------------------------------------------------------
+// Inclusion Verification Tests
+// ------------------------------------------------------------
+
+/// TC-M-06: Round-trip -- compute root then verify_inclusion must not panic.
 #[test]
 fn test_verify_inclusion_correct_root() {
     let leaf: Field = 42;
@@ -89,6 +125,19 @@ fn test_verify_inclusion_correct_root() {
     merkle::verify_inclusion(leaf, index, hash_path, correct_root); // should not panic
 }
 
+/// TC-M-07: Wrong root -- verify_inclusion must reject a fabricated root.
+#[test(should_fail_with = "merkle inclusion check failed: leaf not in tree")]
+fn test_verify_inclusion_wrong_root_fails() {
+    let leaf: Field = 42;
+    let index: Field = 0;
+    let hash_path: [Field; 20] = [0; 20];
+    let wrong_root: Field = 9999; // not the real root
+
+    merkle::verify_inclusion(leaf, index, hash_path, wrong_root);
+}
+
+/// TC-M-08: Wrong index -- root computed for index=0 but claimed index=1 fails.
+/// Leaf position is baked into the root; an incorrect index changes it.
 #[test(should_fail_with = "merkle inclusion check failed: leaf not in tree")]
 fn test_verify_inclusion_wrong_index_fails() {
     let leaf: Field = 42;
@@ -97,4 +146,75 @@ fn test_verify_inclusion_wrong_index_fails() {
     // Compute root for index=0, but verify with index=1 - different root
     let correct_root = merkle::compute_root(leaf, 0, hash_path);
     merkle::verify_inclusion(leaf, 1, hash_path, correct_root);
+}
+
+/// TC-M-09: Tampered sibling -- altering any sibling must change the root,
+/// causing the inclusion check to fail.
+#[test(should_fail_with = "merkle inclusion check failed: leaf not in tree")]
+fn test_verify_inclusion_tampered_sibling_fails() {
+    let leaf: Field  = 55;
+    let index: Field = 0;
+    let hash_path: [Field; 20] = [0; 20];
+    let correct_root = merkle::compute_root(leaf, index, hash_path);
+
+    // Tamper with the sibling at level 5
+    let mut tampered_path = hash_path;
+    tampered_path[5] = 0xdeadbeef;
+
+    // Root will now differ
+    merkle::verify_inclusion(leaf, index, tampered_path, correct_root);
+}
+
+// ------------------------------------------------------------
+// Hash Consistency Tests
+// ------------------------------------------------------------
+
+/// TC-M-10: Left vs right child produce different roots for the same leaf.
+/// Ensures the bit-indexed left/right ordering is applied correctly.
+#[test]
+fn test_left_vs_right_child_produce_different_roots() {
+    let leaf: Field = 7777;
+    let hash_path: [Field; 20] = [0; 20];
+
+    let root_left  = merkle::compute_root(leaf, 0, hash_path); // bit 0 = 0 -> left
+    let root_right = merkle::compute_root(leaf, 1, hash_path); // bit 0 = 1 -> right
+
+    assert(root_left != root_right, "left and right positions must produce different roots");
+}
+
+/// TC-M-11: Swapping sibling and leaf changes the root.
+/// Verifies the hash is order-sensitive (non-commutative in context).
+#[test]
+fn test_sibling_leaf_swap_changes_root() {
+    let leaf_a: Field = 10;
+    let leaf_b: Field = 20;
+
+    let mut path_a: [Field; 20] = [0; 20];
+    path_a[0] = leaf_b; // sibling of a is b
+    let root_a = merkle::compute_root(leaf_a, 0, path_a); // H(a, b) at level 0
+
+    let mut path_b: [Field; 20] = [0; 20];
+    path_b[0] = leaf_a; // sibling of b is a
+    let root_b = merkle::compute_root(leaf_b, 0, path_b); // H(b, a) at level 0 -- but b is at index 0 (left)
+
+    // root_a used leaf_a as left, leaf_b as sibling (right) -> H(a,b) at level 0
+    // root_b used leaf_b as left, leaf_a as sibling (right) -> H(b,a) at level 0
+    // Since hash is not commutative, these should differ
+    assert(root_a != root_b, "swapping left/right children must change the root");
+}
+
+/// TC-M-12: All-zero leaf in otherwise non-zero path.
+/// Simulates an empty leaf slot -- root should still be a valid, non-zero field element.
+#[test]
+fn test_zero_leaf_nonzero_path() {
+    let leaf: Field = 0;
+    let index: Field = 2;
+    let hash_path: [Field; 20] = [1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+    let root = merkle::compute_root(leaf, index, hash_path);
+    // Root is driven by the siblings, so it must be non-zero
+    assert(root != 0, "root with non-zero siblings must not be zero even for a zero leaf");
+
+    // And verify_inclusion must accept the computed root
+    merkle::verify_inclusion(leaf, index, hash_path, root);
 }

--- a/circuits/withdraw/src/main.nr
+++ b/circuits/withdraw/src/main.nr
@@ -90,72 +90,136 @@ fn main(
 // ============================================================
 // Tests - covering all circuit paths
 // ============================================================
+// Total tests: 21
+//   - Happy path tests        (4)
+//   - Merkle / inclusion tests (6)
+//   - Nullifier / hash tests   (4)
+//   - Fee / relayer tests      (4)
+//   - Boundary / misc tests    (3)
+// ============================================================
 
-/// Build a minimal valid Merkle path for a leaf at index 0 in a depth-20 tree.
-/// All siblings are 0 - simulates an empty tree with one note.
-fn build_simple_path(leaf: Field) -> ([Field; 20], Field) {
+// ------------------------------------------------------------
+// Helper: Build a minimal Merkle path for a leaf at a given index.
+// All siblings are zero - simulates an otherwise-empty tree.
+// ------------------------------------------------------------
+
+/// Returns (hash_path, root) for placing `leaf` at `leaf_index` in a
+/// depth-20 tree where all other leaves are zero.
+fn build_path_at(leaf: Field, leaf_index: Field) -> ([Field; 20], Field) {
     let hash_path: [Field; 20] = [0; 20];
-    let root = merkle::compute_root(leaf, 0, hash_path);
+    let root = merkle::compute_root(leaf, leaf_index, hash_path);
     (hash_path, root)
 }
 
+/// Convenience wrapper for leaf at index 0.
+fn build_simple_path(leaf: Field) -> ([Field; 20], Field) {
+    build_path_at(leaf, 0)
+}
+
+// ------------------------------------------------------------
+// Happy Path Tests
+// ------------------------------------------------------------
+
+/// TC-W-01: Standard withdrawal with no relayer.
+/// Full valid proof for a single note at tree index 0.
 #[test]
 fn test_valid_withdrawal() {
     let nullifier: Field = 111;
-    let secret: Field = 222;
+    let secret: Field    = 222;
     let commitment = hash::compute_commitment(nullifier, secret);
 
     let (hash_path, root) = build_simple_path(commitment);
-
     let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
-    let recipient: Field = 0xABCD;
-    let amount: Field = 100_0000000; // 100 XLM in stroops
-    let relayer: Field = 0;
-    let fee: Field = 0;
 
     main(
         nullifier, secret, 0, hash_path,
-        root, nullifier_hash, recipient, amount, relayer, fee
+        root, nullifier_hash, 0xABCD, 100_0000000, 0, 0,
     );
 }
 
+/// TC-W-02: Withdrawal with a relayer and non-zero fee (fee < amount).
+/// Tests the happy-path of the relayer compensation branch.
 #[test]
 fn test_withdrawal_with_relayer_fee() {
     let nullifier: Field = 333;
-    let secret: Field = 444;
+    let secret: Field    = 444;
     let commitment = hash::compute_commitment(nullifier, secret);
 
     let (hash_path, root) = build_simple_path(commitment);
-
     let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
-    let recipient: Field = 0xDEAD;
-    let amount: Field = 100_0000000;
-    let relayer: Field = 0xBEEF;
-    let fee: Field = 1_0000000; // 1 XLM fee
 
     main(
         nullifier, secret, 0, hash_path,
-        root, nullifier_hash, recipient, amount, relayer, fee
+        root, nullifier_hash,
+        0xDEAD,        // recipient
+        100_0000000,   // 100 XLM
+        0xBEEF,        // relayer
+        1_0000000,     // 1 XLM fee
     );
 }
 
+/// TC-W-03: Fee equals amount (fee == amount) -- boundary where fee is exactly equal.
+/// This is the maximum legal fee; the circuit should accept it.
+#[test]
+fn test_withdrawal_fee_equals_amount() {
+    let nullifier: Field = 555;
+    let secret: Field    = 666;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    let (hash_path, root) = build_simple_path(commitment);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+    let amount: Field  = 50_0000000; // 50 XLM
+
+    // fee == amount is valid (relayer takes everything, recipient gets 0)
+    main(
+        nullifier, secret, 0, hash_path,
+        root, nullifier_hash, 0xABCD, amount, 0xBEEF, amount,
+    );
+}
+
+/// TC-W-04: Note at non-zero leaf index (index=7).
+/// Verifies the index decomposition works for arbitrary positions.
+#[test]
+fn test_withdrawal_nonzero_leaf_index() {
+    let nullifier: Field = 777;
+    let secret: Field    = 888;
+    let commitment = hash::compute_commitment(nullifier, secret);
+    let leaf_index: Field = 7; // binary: 0b0...0111
+
+    let (hash_path, root) = build_path_at(commitment, leaf_index);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    main(
+        nullifier, secret, leaf_index, hash_path,
+        root, nullifier_hash, 0x1111, 100_0000000, 0, 0,
+    );
+}
+
+// ------------------------------------------------------------
+// Merkle Inclusion Tests
+// ------------------------------------------------------------
+
+/// TC-W-05: Wrong secret changes the commitment, causing Merkle inclusion to fail.
+/// The reconstructed commitment does not match any leaf in the tree.
 #[test(should_fail_with = "merkle inclusion check failed: leaf not in tree")]
 fn test_wrong_secret_fails() {
     let nullifier: Field = 111;
-    let secret: Field = 222;
+    let secret: Field    = 222;
     let commitment = hash::compute_commitment(nullifier, secret);
 
     let (hash_path, root) = build_simple_path(commitment);
     let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
 
-    // Use wrong secret - commitment won't match leaf in tree
+    // Wrong secret changes commitment -> Merkle inclusion fails
     main(nullifier, 999, 0, hash_path, root, nullifier_hash, 0xABCD, 100_0000000, 0, 0);
 }
 
+/// TC-W-06: Wrong root -- the provided root was never a valid on-chain root.
+/// The computed root from the path will not match, so inclusion fails.
 #[test(should_fail_with = "merkle inclusion check failed: leaf not in tree")]
 fn test_wrong_root_fails() {
     let nullifier: Field = 111;
-    let secret: Field = 222;
+    let secret: Field    = 222;
     let commitment = hash::compute_commitment(nullifier, secret);
 
     let (hash_path, _real_root) = build_simple_path(commitment);
@@ -166,10 +230,81 @@ fn test_wrong_root_fails() {
     main(nullifier, secret, 0, hash_path, wrong_root, nullifier_hash, 0xABCD, 100_0000000, 0, 0);
 }
 
+/// TC-W-07: Wrong leaf index with valid Merkle path for index 0.
+/// Using index=1 with a path computed for index=0 produces a different root.
+#[test(should_fail_with = "merkle inclusion check failed: leaf not in tree")]
+fn test_wrong_leaf_index_fails() {
+    let nullifier: Field = 111;
+    let secret: Field    = 222;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    // Path/root computed for leaf at index 0
+    let (hash_path, root) = build_path_at(commitment, 0);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    // Claim the leaf is at index 1 -> recomputed root won't match
+    main(nullifier, secret, 1, hash_path, root, nullifier_hash, 0xABCD, 100_0000000, 0, 0);
+}
+
+/// TC-W-08: Tampered sibling in the auth path -- one sibling is altered.
+/// The recomputed root will diverge from the real root at that level.
+#[test(should_fail_with = "merkle inclusion check failed: leaf not in tree")]
+fn test_tampered_auth_path_fails() {
+    let nullifier: Field = 321;
+    let secret: Field    = 654;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    let (mut hash_path, root) = build_simple_path(commitment);
+    // Tamper with sibling at level 3
+    hash_path[3] = 0xdeadbeef;
+
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+    main(nullifier, secret, 0, hash_path, root, nullifier_hash, 0xABCD, 100_0000000, 0, 0);
+}
+
+/// TC-W-09: Zero commitment (nullifier=0, secret=0) is still valid if the tree
+/// actually contains that commitment. The circuit should not special-case zero.
+#[test]
+fn test_zero_commitment_valid_if_in_tree() {
+    let nullifier: Field = 0;
+    let secret: Field    = 0;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    let (hash_path, root) = build_simple_path(commitment);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    main(nullifier, secret, 0, hash_path, root, nullifier_hash, 0xABCD, 100_0000000, 0, 0);
+}
+
+/// TC-W-10: Proof for leaf at maximum index (all bits set in 20-bit index = 2^20 - 1).
+/// Exercises the full 20-level path decomposition.
+#[test]
+fn test_max_leaf_index() {
+    let nullifier: Field = 0xAA;
+    let secret: Field    = 0xBB;
+    let commitment = hash::compute_commitment(nullifier, secret);
+    // 2^20 - 1 = 1048575 -- rightmost leaf in the tree
+    let leaf_index: Field = 1048575;
+
+    let (hash_path, root) = build_path_at(commitment, leaf_index);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    main(
+        nullifier, secret, leaf_index, hash_path,
+        root, nullifier_hash, 0xFFFF, 100_0000000, 0, 0,
+    );
+}
+
+// ------------------------------------------------------------
+// Nullifier Hash Tests
+// ------------------------------------------------------------
+
+/// TC-W-11: Fabricated nullifier_hash -- attacker cannot forge the double-spend tag.
+/// Merkle inclusion passes, but the nullifier_hash check fails.
 #[test(should_fail_with = "nullifier_hash mismatch: invalid nullifier or wrong root")]
 fn test_wrong_nullifier_hash_fails() {
     let nullifier: Field = 111;
-    let secret: Field = 222;
+    let secret: Field    = 222;
     let commitment = hash::compute_commitment(nullifier, secret);
 
     let (hash_path, root) = build_simple_path(commitment);
@@ -179,23 +314,76 @@ fn test_wrong_nullifier_hash_fails() {
     main(nullifier, secret, 0, hash_path, root, wrong_nullifier_hash, 0xABCD, 100_0000000, 0, 0);
 }
 
+/// TC-W-12: Nullifier_hash derived from a different nullifier.
+/// Even with a valid Merkle proof, the nullifier_hash must bind to THIS nullifier.
+#[test(should_fail_with = "nullifier_hash mismatch: invalid nullifier or wrong root")]
+fn test_nullifier_hash_from_different_nullifier_fails() {
+    let nullifier: Field  = 111;
+    let secret: Field     = 222;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    let (hash_path, root) = build_simple_path(commitment);
+    // Compute nullifier_hash using a different nullifier
+    let wrong_nh = hash::compute_nullifier_hash(9999, root);
+
+    main(nullifier, secret, 0, hash_path, root, wrong_nh, 0xABCD, 100_0000000, 0, 0);
+}
+
+/// TC-W-13: Nullifier_hash computed for a different root (cross-root replay attempt).
+/// An attacker tries to reuse a nullifier_hash from an old pool snapshot.
+#[test(should_fail_with = "nullifier_hash mismatch: invalid nullifier or wrong root")]
+fn test_nullifier_hash_bound_to_root() {
+    let nullifier: Field  = 111;
+    let secret: Field     = 222;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    let (hash_path, root) = build_simple_path(commitment);
+
+    // Nullifier hash computed against a DIFFERENT root (simulates old snapshot)
+    let stale_root: Field = 0xdeadcafe;
+    let stale_nh = hash::compute_nullifier_hash(nullifier, stale_root);
+
+    // Merkle inclusion uses real root, but nullifier_hash uses stale root -> mismatch
+    main(nullifier, secret, 0, hash_path, root, stale_nh, 0xABCD, 100_0000000, 0, 0);
+}
+
+/// TC-W-14: Zero nullifier_hash -- attacker submits 0 hoping it's skipped.
+#[test(should_fail_with = "nullifier_hash mismatch: invalid nullifier or wrong root")]
+fn test_zero_nullifier_hash_fails() {
+    let nullifier: Field = 111;
+    let secret: Field    = 222;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    let (hash_path, root) = build_simple_path(commitment);
+
+    main(nullifier, secret, 0, hash_path, root, 0, 0xABCD, 100_0000000, 0, 0);
+}
+
+// ------------------------------------------------------------
+// Fee / Relayer Validation Tests
+// ------------------------------------------------------------
+
+/// TC-W-15: Fee exceeds withdrawal amount -- must fail.
+/// Simulates a malicious relayer that sets fee > amount.
 #[test(should_fail_with = "fee cannot exceed withdrawal amount")]
 fn test_fee_exceeds_amount_fails() {
     let nullifier: Field = 555;
-    let secret: Field = 666;
+    let secret: Field    = 666;
     let commitment = hash::compute_commitment(nullifier, secret);
 
     let (hash_path, root) = build_simple_path(commitment);
     let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
 
-    // fee > amount - should fail
+    // fee (100) > amount (10) -- should fail
     main(nullifier, secret, 0, hash_path, root, nullifier_hash, 0xABCD, 10, 0xBEEF, 100);
 }
 
+/// TC-W-16: Non-zero relayer address with zero fee -- must fail.
+/// Relayer must not be set when no fee is charged (prevents griefing).
 #[test(should_fail_with = "relayer must be zero address if fee is zero")]
 fn test_nonzero_relayer_with_zero_fee_fails() {
     let nullifier: Field = 777;
-    let secret: Field = 888;
+    let secret: Field    = 888;
     let commitment = hash::compute_commitment(nullifier, secret);
 
     let (hash_path, root) = build_simple_path(commitment);
@@ -203,4 +391,102 @@ fn test_nonzero_relayer_with_zero_fee_fails() {
 
     // Non-zero relayer with zero fee - should fail
     main(nullifier, secret, 0, hash_path, root, nullifier_hash, 0xABCD, 100_0000000, 0xBEEF, 0);
+}
+
+/// TC-W-17: Zero fee AND zero relayer -- valid (no relayer path).
+/// This is the normal self-serve withdrawal with no relayer.
+#[test]
+fn test_zero_fee_zero_relayer_valid() {
+    let nullifier: Field = 123;
+    let secret: Field    = 456;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    let (hash_path, root) = build_simple_path(commitment);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    main(nullifier, secret, 0, hash_path, root, nullifier_hash, 0xCC, 100_0000000, 0, 0);
+}
+
+/// TC-W-18: Maximum fee with non-zero amount (fee == 1, amount == 1).
+/// Boundary test: smallest non-zero amount and fee that are equal.
+#[test]
+fn test_unit_amount_unit_fee_valid() {
+    let nullifier: Field = 987;
+    let secret: Field    = 654;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    let (hash_path, root) = build_simple_path(commitment);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    // fee == amount == 1 (minimum non-zero -- boundary condition)
+    main(nullifier, secret, 0, hash_path, root, nullifier_hash, 0xBB, 1, 0xAA, 1);
+}
+
+// ------------------------------------------------------------
+// Boundary / Miscellaneous Tests
+// ------------------------------------------------------------
+
+/// TC-W-19: Large but valid field values for all inputs.
+/// Exercises the circuit with hex-literal witnesses to ensure no overflow.
+#[test]
+fn test_withdrawal_large_field_values() {
+    let nullifier: Field = 0x00000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    let secret: Field    = 0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    let commitment = hash::compute_commitment(nullifier, secret);
+
+    let (hash_path, root) = build_simple_path(commitment);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    main(
+        nullifier, secret, 0, hash_path,
+        root, nullifier_hash, 0x1234567890ABCDEF, 999_0000000, 0, 0,
+    );
+}
+
+/// TC-W-20: Two separate notes withdrawn from the same pool root.
+/// Both proofs are valid; nullifier_hashes differ because nullifiers differ.
+#[test]
+fn test_two_notes_same_root_both_valid() {
+    // Note 1
+    let n1: Field = 0xAA; let s1: Field = 0xBB;
+    let c1 = hash::compute_commitment(n1, s1);
+
+    // Note 2
+    let n2: Field = 0xCC; let s2: Field = 0xDD;
+    let c2 = hash::compute_commitment(n2, s2);
+
+    // Place both commitments in the same tree (index 0 and 1)
+    let mut path1: [Field; 20] = [0; 20];
+    path1[0] = c2; // sibling of c1 at level 0 is c2
+    let root = merkle::compute_root(c1, 0, path1);
+
+    let mut path2: [Field; 20] = [0; 20];
+    path2[0] = c1; // sibling of c2 at level 0 is c1
+    // root for c2 at index 1 with sibling c1
+    let root2 = merkle::compute_root(c2, 1, path2);
+
+    // Both should compute the same global root
+    assert(root == root2, "both notes must share the same tree root");
+
+    let nh1 = hash::compute_nullifier_hash(n1, root);
+    let nh2 = hash::compute_nullifier_hash(n2, root);
+
+    main(n1, s1, 0, path1, root, nh1, 0xA1, 1_0000000, 0, 0);
+    main(n2, s2, 1, path2, root, nh2, 0xA2, 1_0000000, 0, 0);
+}
+
+/// TC-W-21: Nullifier hashes for same nullifier in different roots must differ.
+/// Critical cross-pool replay prevention check.
+#[test]
+fn test_nullifier_hash_differs_across_roots() {
+    let nullifier: Field = 0x1234;
+
+    // Two different Merkle roots (simulating two pool timestamps)
+    let root_a: Field = 1111;
+    let root_b: Field = 2222;
+
+    let nh_a = hash::compute_nullifier_hash(nullifier, root_a);
+    let nh_b = hash::compute_nullifier_hash(nullifier, root_b);
+
+    assert(nh_a != nh_b, "same nullifier in different roots must yield different nullifier_hashes");
 }


### PR DESCRIPTION


## Add Comprehensive Edge Case Tests for All Circuits

Closes #3

### Summary

Expanded test coverage from **20 to 53 test cases** across all three Noir circuits, covering edge cases, boundary conditions, and attack scenarios.

### Test Coverage

| Circuit | Before | After | New |
|---|---|---|---|
| `commitment/src/main.nr` | 7 | 16 | +9 |
| `withdraw/src/main.nr` | 6 | 21 | +15 |
| `merkle/src/lib.nr` | 7 | 12 | +5 |
| `lib/src/validation/test_helpers.nr` | 0 | 4 | +4 |
| **Total** | **20** | **53** | **+33** |

### What's Tested

- **Commitment circuit**: Zero/boundary values, near-max BN254 field elements, hash non-symmetry, collision resistance, off-by-one tampering, adjacent nullifier distinguishability
- **Withdrawal circuit**: Wrong leaf index, tampered auth path, zero commitment in tree, max leaf index (2^20-1), cross-root nullifier replay, zero nullifier hash attack, fee == amount boundary, two-note same-tree proofs
- **Merkle library**: Max index root computation, tampered sibling inclusion failure, sibling/leaf swap detection, zero leaf with non-zero path
- **Test helpers** (new file): Reusable fixture builders (`build_valid_fixture`, `build_two_leaf_tree`, `tamper_path`), KAT constant vectors, self-validation tests

### Other Changes

- **Fixed deprecated `u1` → `bool`** in `lib/src/merkle/mod.nr` (required by current Nargo)
- **Added `lib` to workspace** in `Nargo.toml` so helper tests run with `nargo test --workspace`
- **Created `circuits/TEST_VECTORS.md`** documenting all 53 test cases with IDs, scenarios, and expected outcomes

### Verification

```
$ nargo test --workspace

[commitment] 16 tests passed
[lib] 4 tests passed
[merkle] 12 tests passed
[withdraw] 21 tests passed
```

All 53 tests pass. ✅