### PR TITLE
ZK-006: add reproducible artifact manifest validation

### DIFF
--- a/artifacts/zk/manifest.json
+++ b/artifacts/zk/manifest.json
@@ -1,11 +1,20 @@
 {
-  "version": "1.0",
-  "backend": "barretenberg",
+  "schemaVersion": "1.0",
   "circuits": {
     "withdraw": {
+      "circuitId": "withdraw",
+      "artifact": "withdraw.json",
       "path": "withdraw.json",
-      "checksum": "0x0",
-      "root_depth": 20
+      "artifactHash": "79121f029f2e694e898b68f0a45dc7924bcc8abccad5c0c38913aebde54e8aad",
+      "checksum": "79121f029f2e694e898b68f0a45dc7924bcc8abccad5c0c38913aebde54e8aad",
+      "backend": "barretenberg",
+      "backendVersion": "unknown",
+      "compiler": "nargo",
+      "compilerVersion": "unknown",
+      "generatedAt": "2026-04-24T22:31:10.379Z",
+      "metadata": {
+        "noirVersion": "0.31.0"
+      }
     }
   }
 }

--- a/scripts/build-circuits.sh
+++ b/scripts/build-circuits.sh
@@ -14,4 +14,7 @@ for dir in circuits/*/; do
   fi
 done
 
+echo "🧾 Generating artifact manifest..."
+node scripts/generate-zk-manifest.mjs
+
 echo "✅ All circuits built successfully"

--- a/scripts/generate-zk-manifest.mjs
+++ b/scripts/generate-zk-manifest.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { createHash } from 'crypto';
+import { readdir, readFile, writeFile } from 'fs/promises';
+import { join, basename } from 'path';
+import { execFileSync } from 'child_process';
+
+const repoRoot = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const artifactsDir = join(repoRoot, 'artifacts', 'zk');
+const manifestPath = join(artifactsDir, 'manifest.json');
+
+async function readTextIfExists(path, fallback = 'unknown') {
+  try {
+    return (await readFile(path, 'utf8')).trim();
+  } catch {
+    return fallback;
+  }
+}
+
+function commandVersion(command, args) {
+  try {
+    return execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+      .trim()
+      .split('\n')[0];
+  } catch {
+    return 'unknown';
+  }
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+const noirVersion = await readTextIfExists(join(repoRoot, '.noir-version'));
+const compilerVersion = commandVersion('nargo', ['--version']);
+const backendVersion = commandVersion('bb', ['--version']);
+const files = (await readdir(artifactsDir))
+  .filter((file) => file.endsWith('.json'))
+  .filter((file) => !['manifest.json', 'constraint_baselines.json'].includes(file))
+  .sort();
+
+const circuits = {};
+for (const file of files) {
+  const bytes = await readFile(join(artifactsDir, file));
+  const circuitId = basename(file, '.json');
+  circuits[circuitId] = {
+    circuitId,
+    artifact: file,
+    path: file,
+    artifactHash: sha256(bytes),
+    checksum: sha256(bytes),
+    backend: 'barretenberg',
+    backendVersion,
+    compiler: 'nargo',
+    compilerVersion,
+    generatedAt: new Date().toISOString(),
+    metadata: {
+      noirVersion,
+    },
+  };
+}
+
+const manifest = {
+  schemaVersion: '1.0',
+  circuits,
+};
+
+await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`wrote ${manifestPath} with ${files.length} circuit artifact(s)`);

--- a/sdk/src/artifact_manifest.ts
+++ b/sdk/src/artifact_manifest.ts
@@ -1,0 +1,130 @@
+export interface CircuitArtifactManifestEntry {
+  circuitId: string;
+  artifact: string;
+  /** Backward-compatible alias for artifact used by existing harnesses. */
+  path?: string;
+  artifactHash: string;
+  /** Backward-compatible alias for artifactHash used by existing manifests. */
+  checksum?: string;
+  backend: string;
+  backendVersion: string;
+  compiler: string;
+  compilerVersion: string;
+  generatedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ArtifactManifest {
+  schemaVersion: string;
+  circuits: Record<string, CircuitArtifactManifestEntry>;
+}
+
+export interface ValidateArtifactManifestOptions {
+  circuitId: string;
+  artifactFile?: string;
+  artifactBytes?: Uint8Array | string;
+  sha256?: (data: Uint8Array | string) => string;
+  backend?: string;
+  backendVersion?: string;
+  compiler?: string;
+  compilerVersion?: string;
+}
+
+export class ArtifactManifestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArtifactManifestError';
+  }
+}
+
+function normalizeHash(hash: string): string {
+  return hash.toLowerCase().replace(/^0x/, '');
+}
+
+function assertHexSha256(hash: string, field: string): void {
+  if (!/^(0x)?[0-9a-fA-F]{64}$/.test(hash)) {
+    throw new ArtifactManifestError(`${field} must be a sha256 hex digest`);
+  }
+}
+
+export function getCircuitManifestEntry(
+  manifest: ArtifactManifest,
+  circuitId: string
+): CircuitArtifactManifestEntry {
+  if (!manifest || typeof manifest !== 'object') {
+    throw new ArtifactManifestError('Artifact manifest is missing or invalid');
+  }
+  if (manifest.schemaVersion !== '1.0') {
+    throw new ArtifactManifestError(`Unsupported artifact manifest schemaVersion: ${manifest.schemaVersion}`);
+  }
+  const entry = manifest.circuits?.[circuitId];
+  if (!entry) {
+    throw new ArtifactManifestError(`Artifact manifest does not contain circuit: ${circuitId}`);
+  }
+  if (entry.circuitId !== circuitId) {
+    throw new ArtifactManifestError(
+      `Manifest circuit id mismatch: expected ${circuitId}, got ${entry.circuitId}`
+    );
+  }
+  const artifact = entry.artifact || entry.path;
+  const artifactHash = entry.artifactHash || entry.checksum;
+  if (!artifact) {
+    throw new ArtifactManifestError(`Manifest entry for ${circuitId} is missing artifact filename`);
+  }
+  if (!artifactHash) {
+    throw new ArtifactManifestError(`Manifest entry for ${circuitId} is missing artifact hash`);
+  }
+  assertHexSha256(artifactHash, `${circuitId}.artifactHash`);
+  return { ...entry, artifact, path: entry.path || artifact, artifactHash, checksum: entry.checksum || artifactHash };
+}
+
+export function validateArtifactManifest(
+  manifest: ArtifactManifest,
+  options: ValidateArtifactManifestOptions
+): CircuitArtifactManifestEntry {
+  const entry = getCircuitManifestEntry(manifest, options.circuitId);
+
+  if (options.artifactFile && entry.artifact !== options.artifactFile) {
+    throw new ArtifactManifestError(
+      `Artifact filename mismatch for ${options.circuitId}: expected ${entry.artifact}, got ${options.artifactFile}`
+    );
+  }
+
+  if (options.backend && entry.backend !== options.backend) {
+    throw new ArtifactManifestError(
+      `Backend mismatch for ${options.circuitId}: expected ${entry.backend}, got ${options.backend}`
+    );
+  }
+
+  if (options.backendVersion && entry.backendVersion !== options.backendVersion) {
+    throw new ArtifactManifestError(
+      `Backend version mismatch for ${options.circuitId}: expected ${entry.backendVersion}, got ${options.backendVersion}`
+    );
+  }
+
+  if (options.compiler && entry.compiler !== options.compiler) {
+    throw new ArtifactManifestError(
+      `Compiler mismatch for ${options.circuitId}: expected ${entry.compiler}, got ${options.compiler}`
+    );
+  }
+
+  if (options.compilerVersion && entry.compilerVersion !== options.compilerVersion) {
+    throw new ArtifactManifestError(
+      `Compiler version mismatch for ${options.circuitId}: expected ${entry.compilerVersion}, got ${options.compilerVersion}`
+    );
+  }
+
+  if (options.artifactBytes) {
+    if (!options.sha256) {
+      throw new ArtifactManifestError('sha256 function is required when artifactBytes are provided');
+    }
+    const actualHash = options.sha256(options.artifactBytes);
+    if (normalizeHash(actualHash) !== normalizeHash(entry.artifactHash)) {
+      throw new ArtifactManifestError(
+        `Artifact hash mismatch for ${options.circuitId}: expected ${entry.artifactHash}, got ${actualHash}`
+      );
+    }
+  }
+
+  return entry;
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,3 +1,4 @@
+export * from './artifact_manifest';
 export * from './backends';
 export * from './benchmark';
 export * from './encoding';

--- a/sdk/test/artifact_manifest.test.ts
+++ b/sdk/test/artifact_manifest.test.ts
@@ -1,0 +1,80 @@
+import { createHash } from 'crypto';
+import {
+  ArtifactManifest,
+  ArtifactManifestError,
+  validateArtifactManifest,
+} from '../src/artifact_manifest';
+
+const encoder = new TextEncoder();
+const sha256 = (data: Uint8Array | string) =>
+  createHash('sha256')
+    .update(typeof data === 'string' ? encoder.encode(data) : data)
+    .digest('hex');
+
+const manifest: ArtifactManifest = {
+  schemaVersion: '1.0',
+  circuits: {
+    withdraw: {
+      circuitId: 'withdraw',
+      artifact: 'withdraw.json',
+      artifactHash: sha256('artifact-v1'),
+      backend: 'barretenberg',
+      backendVersion: '0.87.0',
+      compiler: 'nargo',
+      compilerVersion: '1.0.0-beta.3',
+      metadata: { rootDepth: 20 },
+    },
+  },
+};
+
+describe('artifact manifest validation', () => {
+  it('accepts matching artifact provenance and hash data', () => {
+    const entry = validateArtifactManifest(manifest, {
+      circuitId: 'withdraw',
+      artifactFile: 'withdraw.json',
+      artifactBytes: 'artifact-v1',
+      sha256,
+      backend: 'barretenberg',
+      backendVersion: '0.87.0',
+      compiler: 'nargo',
+      compilerVersion: '1.0.0-beta.3',
+    });
+
+    expect(entry.circuitId).toBe('withdraw');
+    expect(entry.metadata?.rootDepth).toBe(20);
+  });
+
+  it('refuses missing circuits before proof generation uses an artifact', () => {
+    expect(() =>
+      validateArtifactManifest(manifest, {
+        circuitId: 'deposit',
+      })
+    ).toThrow(ArtifactManifestError);
+  });
+
+  it('refuses artifact hash mismatches', () => {
+    expect(() =>
+      validateArtifactManifest(manifest, {
+        circuitId: 'withdraw',
+        artifactBytes: 'tampered',
+        sha256,
+      })
+    ).toThrow(/Artifact hash mismatch/);
+  });
+
+  it('refuses backend and compiler version mismatches', () => {
+    expect(() =>
+      validateArtifactManifest(manifest, {
+        circuitId: 'withdraw',
+        backendVersion: '0.88.0',
+      })
+    ).toThrow(/Backend version mismatch/);
+
+    expect(() =>
+      validateArtifactManifest(manifest, {
+        circuitId: 'withdraw',
+        compilerVersion: '0.0.0',
+      })
+    ).toThrow(/Compiler version mismatch/);
+  });
+});


### PR DESCRIPTION
Closes #250

## Summary
- adds a generated machine-readable ZK artifact manifest with circuit id, artifact filename, SHA-256 hash, backend/compiler provenance, and Noir version metadata
- wires manifest generation into the circuit build script
- exports SDK manifest validation helpers so proof generation callers can refuse missing, tampered, or version-mismatched artifacts before proving/verifying
- keeps backward-compatible `path`/`checksum` fields used by the existing verification harness

## Verification
- `cd sdk && npm test -- --runInBand`
- `cd sdk && npm run build`