### PR TITLE
ZK-058: Add browser-safe note randomness boundary

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -5,6 +5,7 @@ export * from './errors';
 export * from './merkle';
 export * from './note';
 export * from './proof';
+export * from './random';
 export * from './gas';
 export * from './stealth';
 export * from './withdraw';

--- a/sdk/src/note.ts
+++ b/sdk/src/note.ts
@@ -1,4 +1,20 @@
-import { createHash, randomBytes } from 'crypto';
+import { secureRandomBytes } from './random';
+
+function sha256(bytes: Buffer): Buffer {
+  try {
+    // Runtime lookup keeps production note generation browser-loadable instead
+    // of eagerly importing Node's crypto module at SDK module evaluation time.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const nodeCrypto = require('crypto') as { createHash?: (algorithm: string) => { update(data: Buffer): { digest(): Buffer } } };
+    if (typeof nodeCrypto.createHash === 'function') {
+      return nodeCrypto.createHash('sha256').update(bytes).digest();
+    }
+  } catch {
+    // Fall through to the clear runtime error below.
+  }
+
+  throw new Error('Synchronous SHA-256 requires Node crypto in this SDK build');
+}
 
 // ---------------------------------------------------------------------------
 // Backup format constants
@@ -65,7 +81,7 @@ export class Note {
    * Create a new random note for a specific pool.
    */
   static generate(poolId: string, amount: bigint): Note {
-    return new Note(randomBytes(31), randomBytes(31), poolId, amount);
+    return new Note(secureRandomBytes(31), secureRandomBytes(31), poolId, amount);
   }
 
   /**
@@ -82,7 +98,7 @@ export class Note {
       this.secret,
       Buffer.from(this.poolId, 'hex'),
     ]);
-    return createHash('sha256').update(input).digest();
+    return sha256(input);
   }
 
   // ---------------------------------------------------------------------------
@@ -121,7 +137,7 @@ export class Note {
     payload.writeBigUInt64BE(this.amount, offset);
     offset += 8;
 
-    const checksum = createHash('sha256').update(payload.subarray(0, offset)).digest();
+    const checksum = sha256(payload.subarray(0, offset));
     checksum.copy(payload, offset, 0, 4);
 
     return BACKUP_PREFIX + payload.toString('hex');
@@ -170,7 +186,7 @@ export class Note {
 
     // Verify checksum over bytes [0..102]
     const storedChecksum = payload.subarray(103, 107);
-    const computed = createHash('sha256').update(payload.subarray(0, 103)).digest();
+    const computed = sha256(payload.subarray(0, 103));
     if (!computed.subarray(0, 4).equals(storedChecksum)) {
       throw new NoteBackupError(
         'Note backup checksum mismatch: data may be corrupt or truncated',

--- a/sdk/src/random.ts
+++ b/sdk/src/random.ts
@@ -1,0 +1,100 @@
+export interface SecureRandomSource {
+  randomBytes(length: number): Buffer;
+}
+
+export class SecureRandomUnavailableError extends Error {
+  constructor(message = 'Secure random bytes are unavailable in this runtime') {
+    super(message);
+    this.name = 'SecureRandomUnavailableError';
+  }
+}
+
+export type CryptoLike = {
+  getRandomValues?: <T extends ArrayBufferView | null>(array: T) => T;
+};
+
+type RuntimeGlobal = typeof globalThis & {
+  crypto?: CryptoLike;
+  msCrypto?: CryptoLike;
+};
+
+let overrideRandomSource: SecureRandomSource | undefined;
+
+function getRuntimeCrypto(): CryptoLike | undefined {
+  const runtime = globalThis as RuntimeGlobal;
+  return runtime.crypto ?? runtime.msCrypto;
+}
+
+function browserRandomBytes(length: number, cryptoImpl: CryptoLike): Buffer {
+  if (!cryptoImpl.getRandomValues) {
+    throw new SecureRandomUnavailableError('Runtime crypto does not expose getRandomValues');
+  }
+
+  const bytes = new Uint8Array(length);
+  // Web Crypto limits getRandomValues calls to 65,536 bytes. Note generation only
+  // asks for 31-byte scalars, but chunking keeps the boundary generally safe.
+  for (let offset = 0; offset < bytes.length; offset += 65536) {
+    cryptoImpl.getRandomValues(bytes.subarray(offset, Math.min(offset + 65536, bytes.length)));
+  }
+  return Buffer.from(bytes);
+}
+
+function nodeRandomBytes(length: number): Buffer | undefined {
+  try {
+    // Keep this as a runtime lookup instead of a top-level import so browser
+    // bundles can load the SDK without eagerly requiring Node's crypto module.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const nodeCrypto = require('crypto') as { randomBytes?: (size: number) => Buffer };
+    if (typeof nodeCrypto.randomBytes === 'function') {
+      return nodeCrypto.randomBytes(length);
+    }
+  } catch {
+    // Ignore and fall through to the clear failure below.
+  }
+  return undefined;
+}
+
+export function secureRandomBytesForRuntime(
+  length: number,
+  cryptoImpl: CryptoLike | undefined,
+  nodeSource: ((size: number) => Buffer | undefined) | undefined
+): Buffer {
+  if (!Number.isSafeInteger(length) || length <= 0) {
+    throw new RangeError('Random byte length must be a positive safe integer');
+  }
+
+  if (cryptoImpl?.getRandomValues) {
+    return browserRandomBytes(length, cryptoImpl);
+  }
+
+  const nodeBytes = nodeSource?.(length);
+  if (nodeBytes) {
+    return nodeBytes;
+  }
+
+  throw new SecureRandomUnavailableError(
+    'Secure random bytes require Web Crypto getRandomValues or Node crypto.randomBytes'
+  );
+}
+
+export function secureRandomBytes(length: number): Buffer {
+  if (overrideRandomSource) {
+    const bytes = overrideRandomSource.randomBytes(length);
+    if (!Buffer.isBuffer(bytes) || bytes.length !== length) {
+      throw new SecureRandomUnavailableError(`Injected random source must return exactly ${length} bytes`);
+    }
+    return Buffer.from(bytes);
+  }
+
+  return secureRandomBytesForRuntime(length, getRuntimeCrypto(), nodeRandomBytes);
+}
+
+export function withSecureRandomSourceForTesting<T>(source: SecureRandomSource | undefined, fn: () => T): T {
+  const previous = overrideRandomSource;
+  overrideRandomSource = source;
+  try {
+    return fn();
+  } finally {
+    overrideRandomSource = previous;
+  }
+}

--- a/sdk/test/random.test.ts
+++ b/sdk/test/random.test.ts
@@ -1,0 +1,62 @@
+import { Note } from '../src/note';
+import {
+  secureRandomBytesForRuntime,
+  SecureRandomUnavailableError,
+  withSecureRandomSourceForTesting,
+} from '../src/random';
+
+describe('secure randomness boundary', () => {
+  test('Note.generate uses the injectable secure randomness boundary', () => {
+    let calls = 0;
+    const note = withSecureRandomSourceForTesting(
+      {
+        randomBytes(length: number): Buffer {
+          calls += 1;
+          return Buffer.alloc(length, calls);
+        },
+      },
+      () => Note.generate('11'.repeat(32), 42n)
+    );
+
+    expect(calls).toBe(2);
+    expect(note.nullifier).toEqual(Buffer.alloc(31, 1));
+    expect(note.secret).toEqual(Buffer.alloc(31, 2));
+  });
+
+  test('prefers browser Web Crypto getRandomValues when available', () => {
+    const bytes = secureRandomBytesForRuntime(
+      4,
+      {
+        getRandomValues(array) {
+          const view = array as Uint8Array;
+          view.set([9, 8, 7, 6]);
+          return array;
+        },
+      },
+      () => Buffer.alloc(4, 1)
+    );
+
+    expect(bytes).toEqual(Buffer.from([9, 8, 7, 6]));
+  });
+
+  test('falls back to Node crypto source when Web Crypto is absent', () => {
+    const bytes = secureRandomBytesForRuntime(3, undefined, (length) => Buffer.alloc(length, 5));
+
+    expect(bytes).toEqual(Buffer.from([5, 5, 5]));
+  });
+
+  test('fails clearly when no secure randomness source exists', () => {
+    expect(() => secureRandomBytesForRuntime(3, undefined, undefined)).toThrow(SecureRandomUnavailableError);
+  });
+
+  test('rejects deterministic testing sources that return the wrong length', () => {
+    expect(() =>
+      withSecureRandomSourceForTesting(
+        {
+          randomBytes: () => Buffer.alloc(1),
+        },
+        () => Note.generate('22'.repeat(32), 1n)
+      )
+    ).toThrow(SecureRandomUnavailableError);
+  });
+});


### PR DESCRIPTION
## Summary
- adds a runtime-safe secure randomness boundary for SDK note generation
- supports browser Web Crypto `getRandomValues` and Node `crypto.randomBytes` without a top-level Node crypto import
- keeps deterministic/randomness injection isolated for tests and fails clearly when no secure source is available

## Verification
- `npm test -- --runInBand random.test.ts`
- `npm run build`

Note: full `npm test -- --runInBand` currently fails on pre-existing/mainline unrelated witness/public-input expectations (for example `golden_vectors.test.ts` expects the old `packWithdrawalPublicInputs` arity and malformed witness tests expect `WitnessValidationError` while current code wraps `ProvingError`).

Closes #302
