### PR TITLE
Add: added explcit leaf-index

### DIFF
--- a/circuits/Nargo.toml
+++ b/circuits/Nargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+# Production withdrawal artifacts in this workspace are fixed to depth-20.
+# Offline miniature-depth trees are supported in SDK/tooling only.
 members = [
     "commitment",
     "lib",

--- a/circuits/TEST_VECTORS.md
+++ b/circuits/TEST_VECTORS.md
@@ -7,13 +7,13 @@ Run tests with: `cd circuits && nargo test`
 
 ## Overview
 
-| Circuit | File | Tests |
-|---|---|---|
-| Commitment | `commitment/src/main.nr` | 16 |
-| Withdrawal | `withdraw/src/main.nr` | 21 |
-| Merkle Library | `merkle/src/lib.nr` | 12 |
-| Test Helpers | `lib/src/validation/test_helpers.nr` | 4 |
-| **Total** | | **53** |
+| Circuit        | File                                 | Tests  |
+| -------------- | ------------------------------------ | ------ |
+| Commitment     | `commitment/src/main.nr`             | 16     |
+| Withdrawal     | `withdraw/src/main.nr`               | 21     |
+| Merkle Library | `merkle/src/lib.nr`                  | 12     |
+| Test Helpers   | `lib/src/validation/test_helpers.nr` | 4      |
+| **Total**      |                                      | **53** |
 
 ---
 
@@ -21,39 +21,39 @@ Run tests with: `cd circuits && nargo test`
 
 ### Happy Path
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-C-01 | `test_valid_commitment` | Small field values (nullifier=1, secret=2) | PASS |
-| TC-C-02 | `test_valid_commitment_large_values` | Hex-encoded values (100, 1000) | PASS |
-| TC-C-03 | `test_valid_commitment_near_max_field` | Values near BN254 field limit (2^253) | PASS |
-| TC-C-04 | `test_commitment_is_deterministic` | Same inputs called twice yield equal commitment | PASS |
+| ID      | Test Name                              | Scenario                                        | Expected |
+| ------- | -------------------------------------- | ----------------------------------------------- | -------- |
+| TC-C-01 | `test_valid_commitment`                | Small field values (nullifier=1, secret=2)      | PASS     |
+| TC-C-02 | `test_valid_commitment_large_values`   | Hex-encoded values (100, 1000)                  | PASS     |
+| TC-C-03 | `test_valid_commitment_near_max_field` | Values near BN254 field limit (2^253)           | PASS     |
+| TC-C-04 | `test_commitment_is_deterministic`     | Same inputs called twice yield equal commitment | PASS     |
 
 ### Zero / Boundary Values
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-C-05 | `test_zero_inputs_valid_commitment` | nullifier=0, secret=0 → H(0,0) is valid | PASS |
-| TC-C-06 | `test_zero_nullifier_nonzero_secret` | nullifier=0, secret=12345 | PASS |
-| TC-C-07 | `test_nonzero_nullifier_zero_secret` | nullifier=99999, secret=0 | PASS |
-| TC-C-08 | `test_identical_nullifier_and_secret` | nullifier == secret == 7777 | PASS |
+| ID      | Test Name                             | Scenario                                | Expected |
+| ------- | ------------------------------------- | --------------------------------------- | -------- |
+| TC-C-05 | `test_zero_inputs_valid_commitment`   | nullifier=0, secret=0 → H(0,0) is valid | PASS     |
+| TC-C-06 | `test_zero_nullifier_nonzero_secret`  | nullifier=0, secret=12345               | PASS     |
+| TC-C-07 | `test_nonzero_nullifier_zero_secret`  | nullifier=99999, secret=0               | PASS     |
+| TC-C-08 | `test_identical_nullifier_and_secret` | nullifier == secret == 7777             | PASS     |
 
 ### Collision / Uniqueness
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-C-09 | `test_no_commitment_collision_different_inputs` | H(1,2) ≠ H(3,4) | PASS (distinct outputs) |
-| TC-C-10 | `test_commitment_is_not_symmetric` | H(10,20) ≠ H(20,10) | PASS (non-symmetric) |
-| TC-C-11 | `test_adjacent_nullifiers_produce_distinct_commitments` | H(1,k) ≠ H(2,k) | PASS (distinct) |
+| ID      | Test Name                                               | Scenario            | Expected                |
+| ------- | ------------------------------------------------------- | ------------------- | ----------------------- |
+| TC-C-09 | `test_no_commitment_collision_different_inputs`         | H(1,2) ≠ H(3,4)     | PASS (distinct outputs) |
+| TC-C-10 | `test_commitment_is_not_symmetric`                      | H(10,20) ≠ H(20,10) | PASS (non-symmetric)    |
+| TC-C-11 | `test_adjacent_nullifiers_produce_distinct_commitments` | H(1,k) ≠ H(2,k)     | PASS (distinct)         |
 
 ### Attack / Failure Cases
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-C-12 | `test_wrong_nullifier_fails` | Wrong nullifier, real commitment | FAIL: "commitment mismatch" |
-| TC-C-13 | `test_wrong_secret_fails` | Wrong secret, real commitment | FAIL: "commitment mismatch" |
-| TC-C-14 | `test_swapped_inputs_fails` | (secret, nullifier) — swapped order | FAIL: "commitment mismatch" |
+| ID      | Test Name                                           | Scenario                                | Expected                    |
+| ------- | --------------------------------------------------- | --------------------------------------- | --------------------------- |
+| TC-C-12 | `test_wrong_nullifier_fails`                        | Wrong nullifier, real commitment        | FAIL: "commitment mismatch" |
+| TC-C-13 | `test_wrong_secret_fails`                           | Wrong secret, real commitment           | FAIL: "commitment mismatch" |
+| TC-C-14 | `test_swapped_inputs_fails`                         | (secret, nullifier) — swapped order     | FAIL: "commitment mismatch" |
 | TC-C-15 | `test_zero_inputs_with_fabricated_commitment_fails` | nullifier=0, secret=0, commitment=12345 | FAIL: "commitment mismatch" |
-| TC-C-16 | `test_off_by_one_commitment_fails` | Real commitment + 1 | FAIL: "commitment mismatch" |
+| TC-C-16 | `test_off_by_one_commitment_fails`                  | Real commitment + 1                     | FAIL: "commitment mismatch" |
 
 ---
 
@@ -61,48 +61,48 @@ Run tests with: `cd circuits && nargo test`
 
 ### Happy Path
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-W-01 | `test_valid_withdrawal` | Standard withdrawal, no relayer | PASS |
-| TC-W-02 | `test_withdrawal_with_relayer_fee` | Relayer with 1 XLM fee | PASS |
-| TC-W-03 | `test_withdrawal_fee_equals_amount` | fee == amount (max legal fee) | PASS |
-| TC-W-04 | `test_withdrawal_nonzero_leaf_index` | Leaf at index=7 (binary 0b0111) | PASS |
+| ID      | Test Name                            | Scenario                        | Expected |
+| ------- | ------------------------------------ | ------------------------------- | -------- |
+| TC-W-01 | `test_valid_withdrawal`              | Standard withdrawal, no relayer | PASS     |
+| TC-W-02 | `test_withdrawal_with_relayer_fee`   | Relayer with 1 XLM fee          | PASS     |
+| TC-W-03 | `test_withdrawal_fee_equals_amount`  | fee == amount (max legal fee)   | PASS     |
+| TC-W-04 | `test_withdrawal_nonzero_leaf_index` | Leaf at index=7 (binary 0b0111) | PASS     |
 
 ### Merkle / Inclusion Tests
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-W-05 | `test_wrong_secret_fails` | Wrong secret changes commitment → Merkle fails | FAIL: "leaf not in tree" |
-| TC-W-06 | `test_wrong_root_fails` | Fabricated root, valid path | FAIL: "leaf not in tree" |
-| TC-W-07 | `test_wrong_leaf_index_fails` | Path for index=0 but claim index=1 | FAIL: "leaf not in tree" |
-| TC-W-08 | `test_tampered_auth_path_fails` | Level-3 sibling overwritten | FAIL: "leaf not in tree" |
-| TC-W-09 | `test_zero_commitment_valid_if_in_tree` | H(0,0) is a leaf; circuit accepts it | PASS |
-| TC-W-10 | `test_max_leaf_index` | Index = 2^20 - 1 (all bits set, depth 20) | PASS |
+| ID      | Test Name                               | Scenario                                       | Expected                 |
+| ------- | --------------------------------------- | ---------------------------------------------- | ------------------------ |
+| TC-W-05 | `test_wrong_secret_fails`               | Wrong secret changes commitment → Merkle fails | FAIL: "leaf not in tree" |
+| TC-W-06 | `test_wrong_root_fails`                 | Fabricated root, valid path                    | FAIL: "leaf not in tree" |
+| TC-W-07 | `test_wrong_leaf_index_fails`           | Path for index=0 but claim index=1             | FAIL: "leaf not in tree" |
+| TC-W-08 | `test_tampered_auth_path_fails`         | Level-3 sibling overwritten                    | FAIL: "leaf not in tree" |
+| TC-W-09 | `test_zero_commitment_valid_if_in_tree` | H(0,0) is a leaf; circuit accepts it           | PASS                     |
+| TC-W-10 | `test_max_leaf_index`                   | Index = 2^20 - 1 (all bits set, depth 20)      | PASS                     |
 
 ### Nullifier Hash Tests
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-W-11 | `test_wrong_nullifier_hash_fails` | Fabricated nullifier_hash (54321) | FAIL: "nullifier_hash mismatch" |
-| TC-W-12 | `test_nullifier_hash_from_different_nullifier_fails` | Hash derived from nullifier=9999 | FAIL: "nullifier_hash mismatch" |
-| TC-W-13 | `test_nullifier_hash_bound_to_root` | Cross-root replay — stale root in nullifier_hash | FAIL: "nullifier_hash mismatch" |
-| TC-W-14 | `test_zero_nullifier_hash_fails` | Attacker submits nullifier_hash=0 | FAIL: "nullifier_hash mismatch" |
+| ID      | Test Name                                            | Scenario                                         | Expected                        |
+| ------- | ---------------------------------------------------- | ------------------------------------------------ | ------------------------------- |
+| TC-W-11 | `test_wrong_nullifier_hash_fails`                    | Fabricated nullifier_hash (54321)                | FAIL: "nullifier_hash mismatch" |
+| TC-W-12 | `test_nullifier_hash_from_different_nullifier_fails` | Hash derived from nullifier=9999                 | FAIL: "nullifier_hash mismatch" |
+| TC-W-13 | `test_nullifier_hash_bound_to_root`                  | Cross-root replay — stale root in nullifier_hash | FAIL: "nullifier_hash mismatch" |
+| TC-W-14 | `test_zero_nullifier_hash_fails`                     | Attacker submits nullifier_hash=0                | FAIL: "nullifier_hash mismatch" |
 
 ### Fee / Relayer Validation
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-W-15 | `test_fee_exceeds_amount_fails` | fee=100 > amount=10 | FAIL: "fee cannot exceed withdrawal amount" |
-| TC-W-16 | `test_nonzero_relayer_with_zero_fee_fails` | relayer≠0, fee=0 | FAIL: "relayer must be zero address if fee is zero" |
-| TC-W-17 | `test_zero_fee_zero_relayer_valid` | No relayer, no fee | PASS |
-| TC-W-18 | `test_unit_amount_unit_fee_valid` | amount=1, fee=1 (min boundary) | PASS |
+| ID      | Test Name                                  | Scenario                       | Expected                                            |
+| ------- | ------------------------------------------ | ------------------------------ | --------------------------------------------------- |
+| TC-W-15 | `test_fee_exceeds_amount_fails`            | fee=100 > amount=10            | FAIL: "fee cannot exceed withdrawal amount"         |
+| TC-W-16 | `test_nonzero_relayer_with_zero_fee_fails` | relayer≠0, fee=0               | FAIL: "relayer must be zero address if fee is zero" |
+| TC-W-17 | `test_zero_fee_zero_relayer_valid`         | No relayer, no fee             | PASS                                                |
+| TC-W-18 | `test_unit_amount_unit_fee_valid`          | amount=1, fee=1 (min boundary) | PASS                                                |
 
 ### Boundary / Miscellaneous
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-W-19 | `test_withdrawal_large_field_values` | Witnesses near BN254 field limit | PASS |
-| TC-W-20 | `test_two_notes_same_root_both_valid` | Two notes at index 0 and 1, shared root | PASS |
+| ID      | Test Name                                  | Scenario                                           | Expected        |
+| ------- | ------------------------------------------ | -------------------------------------------------- | --------------- |
+| TC-W-19 | `test_withdrawal_large_field_values`       | Witnesses near BN254 field limit                   | PASS            |
+| TC-W-20 | `test_two_notes_same_root_both_valid`      | Two notes at index 0 and 1, shared root            | PASS            |
 | TC-W-21 | `test_nullifier_hash_differs_across_roots` | Same nullifier, different roots → different hashes | PASS (distinct) |
 
 ---
@@ -111,30 +111,30 @@ Run tests with: `cd circuits && nargo test`
 
 ### Root Computation
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-M-01 | `test_single_leaf_tree` | Leaf=42 at index=0, manually verified root hash chain | PASS |
-| TC-M-02 | `test_nonempty_leaf_produces_nonzero_root` | Leaf=12345, all-zero path → root ≠ 0 | PASS |
-| TC-M-03 | `test_right_child_position` | Index=1 → H(sibling, leaf) at level 0 | PASS |
-| TC-M-04 | `test_same_leaf_same_root` | Determinism check with non-trivial path | PASS |
-| TC-M-05 | `test_max_index_root_computable` | Index = 1048575 (all 20 bits set) | PASS |
+| ID      | Test Name                                  | Scenario                                              | Expected |
+| ------- | ------------------------------------------ | ----------------------------------------------------- | -------- |
+| TC-M-01 | `test_single_leaf_tree`                    | Leaf=42 at index=0, manually verified root hash chain | PASS     |
+| TC-M-02 | `test_nonempty_leaf_produces_nonzero_root` | Leaf=12345, all-zero path → root ≠ 0                  | PASS     |
+| TC-M-03 | `test_right_child_position`                | Index=1 → H(sibling, leaf) at level 0                 | PASS     |
+| TC-M-04 | `test_same_leaf_same_root`                 | Determinism check with non-trivial path               | PASS     |
+| TC-M-05 | `test_max_index_root_computable`           | Index = 1048575 (all 20 bits set)                     | PASS     |
 
 ### Inclusion Verification
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-M-06 | `test_verify_inclusion_correct_root` | Round-trip: compute root then verify | PASS |
-| TC-M-07 | `test_verify_inclusion_wrong_root_fails` | Wrong root (9999) | FAIL: "leaf not in tree" |
-| TC-M-08 | `test_verify_inclusion_wrong_index_fails` | Root for index=0 claimed at index=1 | FAIL: "leaf not in tree" |
-| TC-M-09 | `test_verify_inclusion_tampered_sibling_fails` | Level-5 sibling overwritten | FAIL: "leaf not in tree" |
+| ID      | Test Name                                      | Scenario                             | Expected                 |
+| ------- | ---------------------------------------------- | ------------------------------------ | ------------------------ |
+| TC-M-06 | `test_verify_inclusion_correct_root`           | Round-trip: compute root then verify | PASS                     |
+| TC-M-07 | `test_verify_inclusion_wrong_root_fails`       | Wrong root (9999)                    | FAIL: "leaf not in tree" |
+| TC-M-08 | `test_verify_inclusion_wrong_index_fails`      | Root for index=0 claimed at index=1  | FAIL: "leaf not in tree" |
+| TC-M-09 | `test_verify_inclusion_tampered_sibling_fails` | Level-5 sibling overwritten          | FAIL: "leaf not in tree" |
 
 ### Hash Consistency
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-M-10 | `test_left_vs_right_child_produce_different_roots` | Same leaf at index=0 vs index=1 | PASS (distinct roots) |
-| TC-M-11 | `test_sibling_leaf_swap_changes_root` | Leaf_A sibling=Leaf_B vs Leaf_B sibling=Leaf_A | PASS (distinct roots) |
-| TC-M-12 | `test_zero_leaf_nonzero_path` | Leaf=0, non-zero path → root≠0, verify_inclusion passes | PASS |
+| ID      | Test Name                                          | Scenario                                                | Expected              |
+| ------- | -------------------------------------------------- | ------------------------------------------------------- | --------------------- |
+| TC-M-10 | `test_left_vs_right_child_produce_different_roots` | Same leaf at index=0 vs index=1                         | PASS (distinct roots) |
+| TC-M-11 | `test_sibling_leaf_swap_changes_root`              | Leaf_A sibling=Leaf_B vs Leaf_B sibling=Leaf_A          | PASS (distinct roots) |
+| TC-M-12 | `test_zero_leaf_nonzero_path`                      | Leaf=0, non-zero path → root≠0, verify_inclusion passes | PASS                  |
 
 ---
 
@@ -142,22 +142,22 @@ Run tests with: `cd circuits && nargo test`
 
 ### Canonical KAT Values
 
-| Symbol | Value | Description |
-|---|---|---|
-| `KAT_NULLIFIER` | `1` | Default nullifier for fixture generation |
-| `KAT_SECRET` | `2` | Default secret for fixture generation |
-| `KAT_LEAF_INDEX` | `0` | Default leaf position |
-| `KAT_AMOUNT` | `100_0000000` | 100 XLM in stroops |
-| `KAT_RECIPIENT` | `0xABCD` | Canonical recipient field value |
+| Symbol           | Value         | Description                              |
+| ---------------- | ------------- | ---------------------------------------- |
+| `KAT_NULLIFIER`  | `1`           | Default nullifier for fixture generation |
+| `KAT_SECRET`     | `2`           | Default secret for fixture generation    |
+| `KAT_LEAF_INDEX` | `0`           | Default leaf position                    |
+| `KAT_AMOUNT`     | `100_0000000` | 100 XLM in stroops                       |
+| `KAT_RECIPIENT`  | `0xABCD`      | Canonical recipient field value          |
 
 ### Helper Self-Tests
 
-| ID | Test Name | Scenario | Expected |
-|---|---|---|---|
-| TC-H-01 | `test_build_valid_fixture_is_consistent` | Fixture root and nullifier_hash are self-consistent | PASS |
-| TC-H-02 | `test_build_two_leaf_tree_shared_root` | Both leaves produce the same root | PASS |
-| TC-H-03 | `test_tamper_path_changes_root` | Tampered sibling at level 3 changes root | PASS |
-| TC-H-04 | `test_build_fixture_at_high_index` | Fixture at index=524288 (bit 19 only) is consistent | PASS |
+| ID      | Test Name                                | Scenario                                            | Expected |
+| ------- | ---------------------------------------- | --------------------------------------------------- | -------- |
+| TC-H-01 | `test_build_valid_fixture_is_consistent` | Fixture root and nullifier_hash are self-consistent | PASS     |
+| TC-H-02 | `test_build_two_leaf_tree_shared_root`   | Both leaves produce the same root                   | PASS     |
+| TC-H-03 | `test_tamper_path_changes_root`          | Tampered sibling at level 3 changes root            | PASS     |
+| TC-H-04 | `test_build_fixture_at_high_index`       | Fixture at index=524288 (bit 19 only) is consistent | PASS     |
 
 ---
 
@@ -174,28 +174,30 @@ sdk/test/golden/vectors.json
 
 ### Coverage
 
-| ID | Scenario | Leaf index | Relayer fee |
-|---|---|---|---|
-| TV-001 | Standard single-note spend | 0 | none |
-| TV-002 | Non-zero sibling in auth path | 7 | 1 XLM |
-| TV-003 | Fee equals amount (boundary) | 0 | full amount |
-| TV-004 | Sparse tree — bit 19 only | 524288 | none |
+| ID     | Scenario                      | Leaf index | Relayer fee |
+| ------ | ----------------------------- | ---------- | ----------- |
+| TV-001 | Standard single-note spend    | 0          | none        |
+| TV-002 | Non-zero sibling in auth path | 7          | 1 XLM       |
+| TV-003 | Fee equals amount (boundary)  | 0          | full amount |
+| TV-004 | Sparse tree — bit 19 only     | 524288     | none        |
 
 ### Format
 
 Each vector captures:
 
-1. **Note preimage** — `nullifier_hex`, `secret_hex`, `pool_id`, `amount`
-2. **Field encodings** — canonical 64-char hex for nullifier and secret after
+1. **Depth metadata** — `production_tree_depth` (fixed protocol depth, currently 20)
+   and `offline_tree_depth` (tooling/test depth used when vectors were emitted)
+2. **Note preimage** — `nullifier_hex`, `secret_hex`, `pool_id`, `amount`
+3. **Field encodings** — canonical 64-char hex for nullifier and secret after
    `bufferToField` reduction modulo the BN254 scalar field prime
-3. **Merkle witness** — `leaf_index`, `path_elements` (20 × 32 bytes), `root`
-4. **Nullifier hash** — `H(nullifier_field, root_field)` using the same algorithm
+4. **Merkle witness** — `leaf_index`, `path_elements` (20 × 32 bytes), `root`
+5. **Nullifier hash** — `H(nullifier_field, root_field)` using the same algorithm
    as the circuit (`compute_nullifier_hash` in `circuits/lib/src/hash/nullifier.nr`)
-5. **Packed public inputs** — ordered as the circuit entrypoint expects:
+6. **Packed public inputs** — ordered as the circuit entrypoint expects:
    `root | nullifier_hash | recipient | amount | relayer | fee`
 
 > **Hash note**: The SDK currently uses SHA-256 as a structural stand-in for BN254
-> Pedersen.  When `@noir-lang/barretenberg` (or equivalent) is wired in, regenerate
+> Pedersen. When `@noir-lang/barretenberg` (or equivalent) is wired in, regenerate
 > the corpus by running the SDK generation script and updating the golden file.
 > Any change to public-input encoding **requires** an explicit fixture update —
 > the test suite will catch stale vectors.

--- a/circuits/lib/src/hash/zeroes.nr
+++ b/circuits/lib/src/hash/zeroes.nr
@@ -9,8 +9,8 @@ pub fn zero_leaf() -> Field {
 /// Level 0 = zero_leaf(); level i = H(zero_node(i-1), zero_node(i-1)).
 pub fn zero_node_at_level(level: u32) -> Field {
     let mut z = zero_leaf();
-    for i in 0_u32..20_u32 {
-        if i < level {
+    for i in 0..20 {
+        if (i as u32) < level {
             z = pair::hash_pair(z, z);
         }
     }
@@ -29,9 +29,11 @@ pub fn zero_sibling_path() -> [Field; 20] {
     path
 }
 
-#[cfg(test)]
 mod tests {
-    use super::*;
+
+    use super::zero_leaf;
+    use super::zero_node_at_level;
+    use super::zero_sibling_path;
 
     #[test]
     fn test_zero_leaf_is_nonzero() {

--- a/circuits/lib/src/merkle/config.nr
+++ b/circuits/lib/src/merkle/config.nr
@@ -1,4 +1,8 @@
 /// Tree depth constant - must match the Soroban contract.
 use crate::constants;
 
-pub global TREE_DEPTH: u32 = constants::MERKLE_TREE_DEPTH;
+/// Fixed production depth used by the withdrawal circuit package.
+pub global PRODUCTION_TREE_DEPTH: u32 = constants::MERKLE_TREE_DEPTH;
+
+/// Alias retained for existing call sites in the circuit library.
+pub global TREE_DEPTH: u32 = PRODUCTION_TREE_DEPTH;

--- a/circuits/lib/src/merkle/index.nr
+++ b/circuits/lib/src/merkle/index.nr
@@ -1,9 +1,55 @@
-use crate::merkle::config;
+/// Decompose the leaf index into exactly TREE_DEPTH (20) bits and verify
+/// that the index reconstructs to the original value.
+///
+/// This is the canonical range check: if the index fits in 20 bits, it is
+/// in [0, 2^20 - 1]. Any field element >= 2^20 will fail because its
+/// bit decomposition cannot round-trip through 20 bits.
+///
+/// # Arguments
+/// - `index` : the leaf position to validate and decompose
+///
+/// # Returns
+/// The 20-bit little-endian decomposition of the index.
+///
+/// # Panics
+/// Asserts if index >= 2^TREE_DEPTH (i.e., it cannot be represented in 20 bits).
+pub fn decompose_and_validate(index: Field) -> [u1; 20] {
+    // Decompose into the full BN254 scalar width first, then assert that
+    // all bits above TREE_DEPTH are zero to enforce index < 2^20.
+    // Using full-width decomposition prevents early constraint failures that
+    // bypass our explicit, deterministic range error message.
+    let full_bits: [u1; 254] = index.to_le_bits();
+
+    for i in 20..254 {
+        assert(
+            full_bits[i] == 0,
+            "leaf index out of range: must be < 2^20",
+        );
+    }
+
+    let mut bits: [u1; 20] = [0; 20];
+    for i in 0..20 {
+        bits[i] = full_bits[i];
+    }
+
+    // Reconstruct the index from the decomposed bits to ensure no
+    // information was lost (i.e., no bits above position 19 were set).
+    let mut recomposed: Field = 0;
+    let mut power: Field = 1; // 2^0 = 1
+    for i in 0..20 {
+        recomposed += (bits[i] as Field) * power;
+        power *= 2;
+    }
+    assert(recomposed == index, "leaf index out of range: must be < 2^20");
+
+    bits
+}
 
 /// Validates that the leaf index is within the valid range for the Merkle tree.
 ///
 /// The tree has TREE_DEPTH = 20, so valid indices are [0, 2^20 - 1].
-/// This ensures oversized field values cannot masquerade as valid Merkle positions.
+/// Uses bit decomposition for a sound in-circuit range proof rather than
+/// a field comparison which could be bypassed by large field elements.
 ///
 /// # Arguments
 /// - `index` : the leaf position to validate
@@ -11,51 +57,121 @@ use crate::merkle::config;
 /// # Panics
 /// Asserts if index >= 2^TREE_DEPTH
 pub fn validate_leaf_index(index: Field) {
-    // Maximum valid index: 2^20 - 1 = 1,048,575
-    let max_index = (1 << config::TREE_DEPTH) - 1;
-    assert(index <= max_index, "leaf index out of range: must be < 2^20");
+    let _ = decompose_and_validate(index);
 }
 
-/// Validates that index bit length doesn't exceed tree depth.
-/// This is a range-proof style validation using bit decomposition.
-pub fn validate_index_bits(index: Field) {
-    let index_bits: [bool; 20] = index.to_le_bits();
-    // If index fits in 20 bits, all higher bits must be 0.
-    // This is implicitly guaranteed by Noir's bit decomposition,
-    // but we document the constraint here for clarity.
-    let _ = index_bits;
-}
-
-#[cfg(test)]
 mod tests {
-    use super::*;
+
+    use super::decompose_and_validate;
+    use super::validate_leaf_index;
+
+    // ========== Valid index tests ==========
 
     #[test]
     fn test_valid_zero_index() {
-        validate_leaf_index(0);
+        let bits = decompose_and_validate(0);
+        for i in 0..20 {
+            assert(bits[i] == 0);
+        }
     }
 
     #[test]
     fn test_valid_max_index() {
-        // 2^20 - 1 = 1,048,575
-        validate_leaf_index(1_048_575);
+        // 2^20 - 1 = 1,048,575 (all bits set)
+        let bits = decompose_and_validate(1_048_575);
+        for i in 0..20 {
+            assert(bits[i] == 1);
+        }
     }
 
     #[test]
-    fn test_boundary_valid() {
-        // Just before max
-        validate_leaf_index(1_048_574);
+    fn test_valid_index_one() {
+        let bits = decompose_and_validate(1);
+        assert(bits[0] == 1);
+        for i in 1..20 {
+            assert(bits[i] == 0);
+        }
     }
 
-    #[test(should_fail)]
+    #[test]
+    fn test_valid_power_of_two() {
+        // 2^10 = 1024
+        let bits = decompose_and_validate(1024);
+        for i in 0..10 {
+            assert(bits[i] == 0);
+        }
+        assert(bits[10] == 1);
+        for i in 11..20 {
+            assert(bits[i] == 0);
+        }
+    }
+
+    #[test]
+    fn test_valid_highest_single_bit() {
+        // 2^19 = 524,288 (only bit 19 set)
+        let bits = decompose_and_validate(524_288);
+        for i in 0..19 {
+            assert(bits[i] == 0);
+        }
+        assert(bits[19] == 1);
+    }
+
+    #[test]
+    fn test_boundary_just_below_max() {
+        // 2^20 - 2 = 1,048,574
+        let bits = decompose_and_validate(1_048_574);
+        assert(bits[0] == 0);
+        for i in 1..20 {
+            assert(bits[i] == 1);
+        }
+    }
+
+    #[test]
+    fn test_valid_arbitrary_index() {
+        // 42 = 0b101010
+        let bits = decompose_and_validate(42);
+        assert(bits[0] == 0);
+        assert(bits[1] == 1);
+        assert(bits[2] == 0);
+        assert(bits[3] == 1);
+        assert(bits[4] == 0);
+        assert(bits[5] == 1);
+    }
+
+    // ========== Invalid index tests ==========
+
+    #[test(should_fail_with = "leaf index out of range: must be < 2^20")]
     fn test_invalid_exceeds_max() {
-        // 2^20 = 1,048,576 is out of range
         validate_leaf_index(1_048_576);
     }
 
-    #[test(should_fail)]
+    #[test(should_fail_with = "leaf index out of range: must be < 2^20")]
     fn test_invalid_large_value() {
-        // Much larger than 2^20
         validate_leaf_index(10_000_000);
+    }
+
+    #[test(should_fail_with = "leaf index out of range: must be < 2^20")]
+    fn test_invalid_power_of_two_boundary() {
+        validate_leaf_index(1_048_576);
+    }
+
+    #[test(should_fail_with = "leaf index out of range: must be < 2^20")]
+    fn test_invalid_2_pow_21() {
+        validate_leaf_index(2_097_152);
+    }
+
+    // ========== Bit decomposition correctness ==========
+
+    #[test]
+    fn test_bits_reconstruct_to_original() {
+        let index: Field = 12345;
+        let bits = decompose_and_validate(index);
+        let mut recomposed: Field = 0;
+        let mut power: Field = 1;
+        for i in 0..20 {
+            recomposed += (bits[i] as Field) * power;
+            power *= 2;
+        }
+        assert(recomposed == index);
     }
 }

--- a/circuits/lib/src/merkle/mod.nr
+++ b/circuits/lib/src/merkle/mod.nr
@@ -4,8 +4,12 @@
 // Provides an incremental Merkle tree path verifier for use
 // in the withdrawal proof circuit.
 //
-// The public API remains small while implementation details are
-// separated into config, root computation, and verification logic.
+// Security: The leaf index is decomposed into exactly 20 bits
+// with a round-trip reconstruction check inside compute_root.
+// This ensures:
+//   1. Indices outside [0, 2^20-1] are rejected deterministically
+//   2. Left/right path decisions use explicit validated bits
+//   3. No unchecked field arithmetic influences tree traversal
 // ============================================================
 
 pub mod config;
@@ -18,26 +22,26 @@ pub global TREE_DEPTH: u32 = config::TREE_DEPTH;
 
 /// Compute the Merkle root from a leaf and its authentication path.
 ///
-/// The leaf index is validated to be within [0, 2^20-1] range.
+/// The leaf index is decomposed into exactly 20 bits and range-validated
+/// internally. Out-of-range indices will cause an assertion failure.
 pub fn compute_root(
     leaf: Field,
     index: Field,
     hash_path: [Field; 20],
 ) -> Field {
-    index::validate_leaf_index(index);
+    // Range validation and bit decomposition happen inside root::compute_root
     root::compute_root(leaf, index, hash_path)
 }
 
 /// Verify that a leaf is included in the Merkle tree with the given root.
 ///
-/// Validates the leaf index before verifying inclusion to prevent
-/// out-of-range indices from being accepted.
+/// The leaf index is range-validated via explicit 20-bit decomposition
+/// before verifying inclusion. Out-of-range indices cause assertion failure.
 pub fn verify_inclusion(
     leaf: Field,
     index: Field,
     hash_path: [Field; 20],
     root: Field,
 ) {
-    index::validate_leaf_index(index);
     verify::verify_inclusion(leaf, index, hash_path, root)
 }

--- a/circuits/lib/src/merkle/root.nr
+++ b/circuits/lib/src/merkle/root.nr
@@ -1,5 +1,6 @@
 use crate::hash;
 use crate::merkle::config;
+use crate::merkle::index;
 
 /// Compute the Merkle root from a leaf and its authentication path.
 ///
@@ -10,18 +11,28 @@ use crate::merkle::config;
 ///
 /// # Returns
 /// The computed Merkle root. Must match the on-chain root to prove inclusion.
+///
+/// # Security
+/// The leaf index is decomposed into exactly 20 bits with a round-trip check.
+/// Left/right decisions at each tree level are driven by these explicit bits,
+/// ensuring that out-of-range indices are rejected and path traversal cannot
+/// be influenced by unchecked field arithmetic.
 pub fn compute_root(
     leaf: Field,
     index: Field,
     hash_path: [Field; 20],
 ) -> Field {
-    // Bit 0 = deepest level (leaf level), bit 19 = root level.
-    let index_bits: [u1; 20] = index.to_le_bits();
+    // Decompose index into 20 bits with range validation.
+    // This guarantees index is in [0, 2^20 - 1] and the bits faithfully
+    // represent the index value (no silent truncation of higher bits).
+    let index_bits: [u1; 20] = index::decompose_and_validate(index);
+
     let mut current = leaf;
 
+    // Bit 0 = deepest level (leaf level), bit 19 = root level.
     for i in 0..config::TREE_DEPTH {
         let is_right: bool = index_bits[i] as bool;
-        let left = if is_right { hash_path[i] } else { current };
+        let left  = if is_right { hash_path[i] } else { current };
         let right = if is_right { current } else { hash_path[i] };
         current = hash::hash_pair(left, right);
     }

--- a/circuits/lib/src/merkle/verify.nr
+++ b/circuits/lib/src/merkle/verify.nr
@@ -4,18 +4,20 @@ use crate::merkle::root;
 ///
 /// # Arguments
 /// - `leaf`      : leaf value to verify
-/// - `index`     : leaf position
+/// - `index`     : leaf position (range-checked to [0, 2^20-1] via bit decomposition)
 /// - `hash_path` : authentication path
 /// - `root`      : expected Merkle root (public)
 ///
 /// # Panics
-/// Asserts if the computed root does not match the expected root.
+/// Asserts if the leaf index is out of range or the computed root does not
+/// match the expected root.
 pub fn verify_inclusion(
     leaf: Field,
     index: Field,
     hash_path: [Field; 20],
     expected_root: Field,
 ) {
+    // compute_root performs explicit 20-bit decomposition with range validation
     let computed_root = root::compute_root(leaf, index, hash_path);
     assert(computed_root == expected_root, "merkle inclusion check failed: leaf not in tree");
 }

--- a/circuits/merkle/src/lib.nr
+++ b/circuits/merkle/src/lib.nr
@@ -218,3 +218,42 @@ fn test_zero_leaf_nonzero_path() {
     // And verify_inclusion must accept the computed root
     merkle::verify_inclusion(leaf, index, hash_path, root);
 }
+
+// ============================================================
+// ZK-020: Leaf Index Range Check Tests
+// ============================================================
+
+/// TC-M-13: Index at 2^20 (first out-of-range value) must be rejected.
+#[test(should_fail_with = "leaf index out of range: must be < 2^20")]
+fn test_out_of_range_index_rejected() {
+    let leaf: Field = 42;
+    let hash_path: [Field; 20] = [0; 20];
+    // 2^20 = 1,048,576 is the first invalid index
+    let _ = merkle::compute_root(leaf, 1_048_576, hash_path);
+}
+
+/// TC-M-14: Very large index must be rejected.
+#[test(should_fail_with = "leaf index out of range: must be < 2^20")]
+fn test_very_large_index_rejected() {
+    let leaf: Field = 42;
+    let hash_path: [Field; 20] = [0; 20];
+    let _ = merkle::compute_root(leaf, 100_000_000, hash_path);
+}
+
+/// TC-M-15: Out-of-range index via verify_inclusion must be rejected.
+#[test(should_fail_with = "leaf index out of range: must be < 2^20")]
+fn test_verify_inclusion_out_of_range_index_fails() {
+    let leaf: Field = 42;
+    let hash_path: [Field; 20] = [0; 20];
+    let fake_root: Field = 999;
+    merkle::verify_inclusion(leaf, 1_048_576, hash_path, fake_root);
+}
+
+/// TC-M-16: Index 2^20 + 1 must be rejected (one past the boundary).
+#[test(should_fail_with = "leaf index out of range: must be < 2^20")]
+fn test_index_just_past_boundary_rejected() {
+    let leaf: Field = 42;
+    let hash_path: [Field; 20] = [0; 20];
+    let _ = merkle::compute_root(leaf, 1_048_577, hash_path);
+}
+

--- a/circuits/withdraw/src/main.nr
+++ b/circuits/withdraw/src/main.nr
@@ -21,7 +21,6 @@
 // ============================================================
 
 mod spend;
-#[cfg(test)]
 mod tests;
 
 /// Full withdrawal proof circuit entrypoint.

--- a/circuits/withdraw/src/spend.nr
+++ b/circuits/withdraw/src/spend.nr
@@ -53,10 +53,11 @@ pub fn verify_withdrawal_constraints(
     let _ = recipient;
 }
 
-#[cfg(test)]
 mod tests {
-    use super::*;
-    use lib::validation::test_helpers::*;
+
+    use super::verify_withdrawal_constraints;
+    use lib::validation::test_helpers::setup_valid_withdrawal;
+
 
     #[test]
     fn test_spend_constraints_happy_path() {

--- a/circuits/withdraw/src/tests.nr
+++ b/circuits/withdraw/src/tests.nr
@@ -326,3 +326,96 @@ fn test_nullifier_hash_differs_across_roots() {
 
     assert(nh_a != nh_b, "same nullifier in different roots must yield different nullifier_hashes");
 }
+
+// ============================================================
+// ZK-020: Leaf Index Boundary and Range Tests
+// ============================================================
+
+#[test(should_fail_with = "leaf index out of range: must be < 2^20")]
+fn test_leaf_index_exceeds_tree_capacity() {
+    let nullifier: Field = 0xAA;
+    let secret: Field    = 0xBB;
+    let pool_id: Field   = 1;
+    let commitment = hash::compute_commitment(nullifier, secret, pool_id);
+
+    // Build a valid path at index 0, then attempt with invalid index 2^20
+    let (hash_path, root) = build_path_at(commitment, 0);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    // 2^20 = 1,048,576 -- first invalid index
+    main(
+        nullifier, secret, 1_048_576, hash_path,
+        pool_id, root, nullifier_hash, 0xFFFF, 100_0000000, 0, 0,
+    );
+}
+
+#[test(should_fail_with = "leaf index out of range: must be < 2^20")]
+fn test_leaf_index_large_out_of_range() {
+    let nullifier: Field = 0xCC;
+    let secret: Field    = 0xDD;
+    let pool_id: Field   = 1;
+    let commitment = hash::compute_commitment(nullifier, secret, pool_id);
+
+    let (hash_path, root) = build_path_at(commitment, 0);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    // Far outside valid range
+    main(
+        nullifier, secret, 99_999_999, hash_path,
+        pool_id, root, nullifier_hash, 0xFFFF, 100_0000000, 0, 0,
+    );
+}
+
+#[test]
+fn test_leaf_index_zero_boundary() {
+    // Index 0 is the minimum valid index
+    let nullifier: Field = 0xEE;
+    let secret: Field    = 0xFF;
+    let pool_id: Field   = 1;
+    let commitment = hash::compute_commitment(nullifier, secret, pool_id);
+    let leaf_index: Field = 0;
+
+    let (hash_path, root) = build_path_at(commitment, leaf_index);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    main(
+        nullifier, secret, leaf_index, hash_path,
+        pool_id, root, nullifier_hash, 0x1234, 100_0000000, 0, 0,
+    );
+}
+
+#[test]
+fn test_leaf_index_max_boundary() {
+    // Index 2^20 - 1 = 1,048,575 is the maximum valid index
+    let nullifier: Field = 0x11;
+    let secret: Field    = 0x22;
+    let pool_id: Field   = 1;
+    let commitment = hash::compute_commitment(nullifier, secret, pool_id);
+    let leaf_index: Field = 1_048_575;
+
+    let (hash_path, root) = build_path_at(commitment, leaf_index);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    main(
+        nullifier, secret, leaf_index, hash_path,
+        pool_id, root, nullifier_hash, 0x5678, 100_0000000, 0, 0,
+    );
+}
+
+#[test]
+fn test_leaf_index_high_bit_only() {
+    // Index 2^19 = 524,288 -- only the highest valid bit is set
+    let nullifier: Field = 0x33;
+    let secret: Field    = 0x44;
+    let pool_id: Field   = 1;
+    let commitment = hash::compute_commitment(nullifier, secret, pool_id);
+    let leaf_index: Field = 524_288;
+
+    let (hash_path, root) = build_path_at(commitment, leaf_index);
+    let nullifier_hash = hash::compute_nullifier_hash(nullifier, root);
+
+    main(
+        nullifier, secret, leaf_index, hash_path,
+        pool_id, root, nullifier_hash, 0x9ABC, 100_0000000, 0, 0,
+    );
+}

--- a/scripts/refresh_manifest.mjs
+++ b/scripts/refresh_manifest.mjs
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 const artifactsDir = path.join(repoRoot, 'artifacts', 'zk');
 const manifestPath = path.join(artifactsDir, 'manifest.json');
+const PRODUCTION_MERKLE_ROOT_DEPTH = 20;
 
 /**
  * Computes a deterministic SHA-256 checksum for a JSON object.
@@ -39,9 +40,9 @@ function main() {
     }
     manifest.circuits[name].checksum = checksum;
     
-    // Hardcoded depths for this protocol version
+    // Production artifact depth is fixed for this protocol version.
     if (name === 'withdraw') {
-      manifest.circuits[name].root_depth = 20;
+      manifest.circuits[name].root_depth = PRODUCTION_MERKLE_ROOT_DEPTH;
     }
   }
 

--- a/sdk/src/merkle.ts
+++ b/sdk/src/merkle.ts
@@ -1,10 +1,38 @@
-import type { MerkleProof } from './proof';
-import { normalizeHex, stableHash32 } from './stable';
-import { WitnessValidationError } from './errors';
-import { FIELD_MODULUS, MERKLE_NODE_BYTE_LENGTH, MERKLE_TREE_DEPTH } from './zk_constants';
+import type { MerkleProof } from "./proof";
+import { normalizeHex, stableHash32 } from "./stable";
+import { WitnessValidationError } from "./errors";
+import {
+  FIELD_MODULUS,
+  MERKLE_NODE_BYTE_LENGTH,
+  MERKLE_TREE_DEPTH as ZK_MERKLE_TREE_DEPTH,
+} from "./zk_constants";
 
-export { MERKLE_TREE_DEPTH };
-export const MERKLE_MAX_LEAF_INDEX = (1 << MERKLE_TREE_DEPTH) - 1;
+export const PRODUCTION_MERKLE_TREE_DEPTH = ZK_MERKLE_TREE_DEPTH;
+export { PRODUCTION_MERKLE_TREE_DEPTH as MERKLE_TREE_DEPTH };
+
+export function assertMerkleDepth(
+  depth: number,
+  label: string = "merkleDepth",
+): number {
+  if (!Number.isInteger(depth) || depth <= 0 || depth > 31) {
+    throw new WitnessValidationError(
+      `${label} must be an integer in [1, 31], received ${depth}`,
+      "MERKLE_PATH",
+      "structure",
+    );
+  }
+  return depth;
+}
+
+export function merkleMaxLeafIndex(
+  depth: number = PRODUCTION_MERKLE_TREE_DEPTH,
+): number {
+  return (1 << assertMerkleDepth(depth)) - 1;
+}
+
+export const MERKLE_MAX_LEAF_INDEX = merkleMaxLeafIndex(
+  PRODUCTION_MERKLE_TREE_DEPTH,
+);
 
 export type CommitmentLike = Buffer | Uint8Array | string;
 
@@ -17,45 +45,78 @@ export interface MerkleCheckpoint {
   leaves?: string[];
 }
 
+export interface BatchSyncResult {
+  insertedLeafIndices: number[];
+  checkpoint: MerkleCheckpoint;
+  root: Buffer;
+}
+
+export interface MerkleFixtureVector {
+  id: string;
+  depth: number;
+  leafIndex: number;
+  rootHex: string;
+  pathElementsHex: string[];
+}
+
+export interface MerkleFixtureGenerationOptions {
+  depth?: number;
+  leafCount?: number;
+  proveLeafIndices?: number[];
+}
+
 function toLeaf(commitment: CommitmentLike): Buffer {
   if (Buffer.isBuffer(commitment) || commitment instanceof Uint8Array) {
     const bytes = Buffer.from(commitment);
-    return bytes.length === 32 ? bytes : stableHash32('leaf-bytes', bytes);
+    return bytes.length === 32 ? bytes : stableHash32("leaf-bytes", bytes);
   }
 
   const normalized = normalizeHex(commitment);
   if (/^[0-9a-f]+$/i.test(normalized) && normalized.length % 2 === 0) {
-    const bytes = Buffer.from(normalized, 'hex');
-    return bytes.length === 32 ? bytes : stableHash32('leaf-hex', bytes);
+    const bytes = Buffer.from(normalized, "hex");
+    return bytes.length === 32 ? bytes : stableHash32("leaf-hex", bytes);
   }
 
-  return stableHash32('leaf-text', commitment);
+  return stableHash32("leaf-text", commitment);
 }
 
 /**
  * Validate the Merkle proof object before it is encoded for the prover.
  * Catches truncated / overlong paths and invalid index range early.
  */
-export function validateMerkleProof(merkleProof: MerkleProof, depth: number = MERKLE_TREE_DEPTH): void {
+export function validateMerkleProof(
+  merkleProof: MerkleProof,
+  depth: number = PRODUCTION_MERKLE_TREE_DEPTH,
+): void {
+  const expectedDepth = assertMerkleDepth(depth);
+
   if (merkleProof.root.length !== MERKLE_NODE_BYTE_LENGTH) {
     throw new WitnessValidationError(
       `Merkle root must be ${MERKLE_NODE_BYTE_LENGTH} bytes, got ${merkleProof.root.length}`,
-      'MERKLE_PATH',
-      'structure'
+      "MERKLE_PATH",
+      "structure",
     );
   }
   if (merkleProof.root.every((b: number) => b === 0)) {
-    throw new WitnessValidationError('Merkle root must be non-zero', 'MERKLE_ROOT', 'domain');
-  }
-  const rootN = BigInt('0x' + merkleProof.root.toString('hex'));
-  if (rootN >= FIELD_MODULUS) {
-    throw new WitnessValidationError('Merkle root must be a canonical field encoding', 'MERKLE_ROOT', 'domain');
-  }
-  if (merkleProof.pathElements.length !== depth) {
     throw new WitnessValidationError(
-      `Merkle path must have ${depth} elements, got ${merkleProof.pathElements.length}`,
-      'MERKLE_PATH',
-      'structure'
+      "Merkle root must be non-zero",
+      "MERKLE_ROOT",
+      "domain",
+    );
+  }
+  const rootN = BigInt("0x" + merkleProof.root.toString("hex"));
+  if (rootN >= FIELD_MODULUS) {
+    throw new WitnessValidationError(
+      "Merkle root must be a canonical field encoding",
+      "MERKLE_ROOT",
+      "domain",
+    );
+  }
+  if (merkleProof.pathElements.length !== expectedDepth) {
+    throw new WitnessValidationError(
+      `Merkle path must have ${expectedDepth} elements, got ${merkleProof.pathElements.length}`,
+      "MERKLE_PATH",
+      "structure",
     );
   }
   for (let i = 0; i < merkleProof.pathElements.length; i++) {
@@ -63,8 +124,8 @@ export function validateMerkleProof(merkleProof: MerkleProof, depth: number = ME
     if (el.length !== MERKLE_NODE_BYTE_LENGTH) {
       throw new WitnessValidationError(
         `Merkle path element at index ${i} must be ${MERKLE_NODE_BYTE_LENGTH} bytes, got ${el.length}`,
-        'MERKLE_PATH',
-        'structure'
+        "MERKLE_PATH",
+        "structure",
       );
     }
   }
@@ -78,10 +139,8 @@ export class LocalMerkleTree {
   private nextIndex: number;
   private root: Buffer;
 
-  constructor(depth: number = 20) {
-    if (!Number.isInteger(depth) || depth <= 0 || depth > 31) {
-      throw new Error(`Merkle depth must be an integer in [1, 31], received ${depth}`);
-    }
+  constructor(depth: number = PRODUCTION_MERKLE_TREE_DEPTH) {
+    assertMerkleDepth(depth);
 
     this.depth = depth;
     this.zeroes = this.buildZeroes(depth);
@@ -94,21 +153,23 @@ export class LocalMerkleTree {
   static fromCheckpoint(checkpoint: MerkleCheckpoint): LocalMerkleTree {
     if (checkpoint.frontier.length !== checkpoint.depth) {
       throw new Error(
-        `Invalid checkpoint: frontier length ${checkpoint.frontier.length} does not match depth ${checkpoint.depth}`
+        `Invalid checkpoint: frontier length ${checkpoint.frontier.length} does not match depth ${checkpoint.depth}`,
       );
     }
 
     const tree = new LocalMerkleTree(checkpoint.depth);
     tree.nextIndex = checkpoint.nextIndex;
-    tree.root = Buffer.from(normalizeHex(checkpoint.root), 'hex');
+    tree.root = Buffer.from(normalizeHex(checkpoint.root), "hex");
 
     for (let i = 0; i < checkpoint.frontier.length; i += 1) {
       const entry = checkpoint.frontier[i];
-      tree.frontier[i] = entry ? Buffer.from(normalizeHex(entry), 'hex') : null;
+      tree.frontier[i] = entry ? Buffer.from(normalizeHex(entry), "hex") : null;
     }
 
     if (checkpoint.leaves) {
-      tree.trackedLeaves = checkpoint.leaves.map((leaf) => Buffer.from(normalizeHex(leaf), 'hex'));
+      tree.trackedLeaves = checkpoint.leaves.map((leaf) =>
+        Buffer.from(normalizeHex(leaf), "hex"),
+      );
     }
 
     return tree;
@@ -164,12 +225,18 @@ export class LocalMerkleTree {
    * This requires that leaves are available in memory.
    */
   generateProof(leafIndex: number): MerkleProof {
-    if (!Number.isInteger(leafIndex) || leafIndex < 0 || leafIndex >= this.nextIndex) {
-      throw new Error(`Leaf index ${leafIndex} is out of range for tree size ${this.nextIndex}`);
+    if (
+      !Number.isInteger(leafIndex) ||
+      leafIndex < 0 ||
+      leafIndex >= this.nextIndex
+    ) {
+      throw new Error(
+        `Leaf index ${leafIndex} is out of range for tree size ${this.nextIndex}`,
+      );
     }
     if (this.trackedLeaves.length < this.nextIndex) {
       throw new Error(
-        'Cannot generate Merkle proof from checkpoint-only tree state; tracked leaves are unavailable.'
+        "Cannot generate Merkle proof from checkpoint-only tree state; tracked leaves are unavailable.",
       );
     }
 
@@ -189,23 +256,29 @@ export class LocalMerkleTree {
       root: this.getRoot(),
       pathElements,
       pathIndices,
-      leafIndex
+      leafIndex,
     };
   }
 
-  createCheckpoint(options: { includeLeaves?: boolean } = {}): MerkleCheckpoint {
+  createCheckpoint(
+    options: { includeLeaves?: boolean } = {},
+  ): MerkleCheckpoint {
     return {
       version: 1,
       depth: this.depth,
       nextIndex: this.nextIndex,
-      root: this.root.toString('hex'),
-      frontier: this.frontier.map((entry) => (entry ? entry.toString('hex') : null)),
-      leaves: options.includeLeaves ? this.trackedLeaves.map((leaf) => leaf.toString('hex')) : undefined
+      root: this.root.toString("hex"),
+      frontier: this.frontier.map((entry) =>
+        entry ? entry.toString("hex") : null,
+      ),
+      leaves: options.includeLeaves
+        ? this.trackedLeaves.map((leaf) => leaf.toString("hex"))
+        : undefined,
     };
   }
 
   private hashPair(left: Buffer, right: Buffer): Buffer {
-    return stableHash32('merkle-node', left, right);
+    return stableHash32("merkle-node", left, right);
   }
 
   private buildZeroes(depth: number): Buffer[] {
@@ -216,7 +289,11 @@ export class LocalMerkleTree {
     return zeroes;
   }
 
-  private nodeAt(level: number, index: number, memo: Map<string, Buffer>): Buffer {
+  private nodeAt(
+    level: number,
+    index: number,
+    memo: Map<string, Buffer>,
+  ): Buffer {
     const key = `${level}:${index}`;
     const existing = memo.get(key);
     if (existing) {
@@ -245,12 +322,68 @@ export class LocalMerkleTree {
 export function syncCommitmentBatch(
   tree: LocalMerkleTree,
   commitments: CommitmentLike[],
-  checkpointOptions: { includeLeaves?: boolean } = {}
+  checkpointOptions: { includeLeaves?: boolean } = {},
 ): BatchSyncResult {
   const insertedLeafIndices = tree.insertBatch(commitments);
   return {
     insertedLeafIndices,
     checkpoint: tree.createCheckpoint(checkpointOptions),
-    root: tree.getRoot()
+    root: tree.getRoot(),
   };
+}
+
+/**
+ * Deterministic fixture helper for offline tooling.
+ *
+ * Production artifacts remain fixed at depth 20. Tooling can explicitly
+ * request a smaller depth to speed up local debugging and vector generation.
+ */
+export function generateMerkleFixtureVectors(
+  options: MerkleFixtureGenerationOptions = {},
+): MerkleFixtureVector[] {
+  const depth = assertMerkleDepth(
+    options.depth ?? PRODUCTION_MERKLE_TREE_DEPTH,
+    "offlineMerkleDepth",
+  );
+  const leafCount = options.leafCount ?? Math.min(8, 1 << depth);
+  if (
+    !Number.isInteger(leafCount) ||
+    leafCount <= 0 ||
+    leafCount > 1 << depth
+  ) {
+    throw new Error(
+      `leafCount must be an integer in [1, ${1 << depth}], received ${leafCount}`,
+    );
+  }
+
+  const proveLeafIndices =
+    options.proveLeafIndices ??
+    Array.from({ length: Math.min(leafCount, 4) }, (_, i) => i);
+
+  const tree = new LocalMerkleTree(depth);
+  const leaves = Array.from({ length: leafCount }, (_, i) =>
+    stableHash32("fixture-leaf", i),
+  );
+  tree.insertBatch(leaves);
+
+  return proveLeafIndices.map((leafIndex, i) => {
+    if (
+      !Number.isInteger(leafIndex) ||
+      leafIndex < 0 ||
+      leafIndex >= leafCount
+    ) {
+      throw new Error(
+        `proveLeafIndices[${i}] is out of range for leafCount ${leafCount}`,
+      );
+    }
+
+    const proof = tree.generateProof(leafIndex);
+    return {
+      id: `fixture-depth-${depth}-leaf-${leafIndex}`,
+      depth,
+      leafIndex,
+      rootHex: proof.root.toString("hex"),
+      pathElementsHex: proof.pathElements.map((entry) => entry.toString("hex")),
+    };
+  });
 }

--- a/sdk/src/proof.ts
+++ b/sdk/src/proof.ts
@@ -1,20 +1,28 @@
-import { Note } from './note';
+import { Note } from "./note";
 import {
   merkleNodeToField,
   noteScalarToField,
   poolIdToField,
   computeNullifierHash,
   stellarAddressToField,
-} from './encoding';
-import { WitnessValidationError } from './errors';
-import { assertValidGroth16ProofBytes, assertValidPreparedWithdrawalWitness } from './witness';
-import { MERKLE_TREE_DEPTH, STELLAR_ZERO_ACCOUNT, ZERO_FIELD_HEX } from './zk_constants';
+} from "./encoding";
+import { WitnessValidationError } from "./errors";
+import {
+  assertValidGroth16ProofBytes,
+  assertValidPreparedWithdrawalWitness,
+} from "./witness";
+import { STELLAR_ZERO_ACCOUNT, ZERO_FIELD_HEX } from "./zk_constants";
+import {
+  PRODUCTION_MERKLE_TREE_DEPTH,
+  assertMerkleDepth,
+  merkleMaxLeafIndex,
+} from "./merkle";
 
 export type ProvingErrorCode =
-  | 'ARTIFACT_ERROR'
-  | 'WITNESS_ERROR'
-  | 'BACKEND_ERROR'
-  | 'FORMATTING_ERROR';
+  | "ARTIFACT_ERROR"
+  | "WITNESS_ERROR"
+  | "BACKEND_ERROR"
+  | "FORMATTING_ERROR";
 
 /**
  * ProvingError
@@ -25,10 +33,10 @@ export class ProvingError extends Error {
   constructor(
     message: string,
     public readonly code: ProvingErrorCode,
-    public readonly cause?: any
+    public readonly cause?: any,
   ) {
     super(message);
-    this.name = 'ProvingError';
+    this.name = "ProvingError";
   }
 }
 
@@ -65,7 +73,9 @@ export interface WithdrawalWitness {
 }
 
 export interface ProofCache {
-  get(key: string): Promise<Uint8Array | Buffer | undefined> | Uint8Array | Buffer | undefined;
+  get(
+    key: string,
+  ): Promise<Uint8Array | Buffer | undefined> | Uint8Array | Buffer | undefined;
   set(key: string, proof: Uint8Array | Buffer): Promise<void> | void;
   delete?(key: string): Promise<void> | void;
 }
@@ -90,7 +100,6 @@ export class InMemoryProofCache implements ProofCache {
     this.entries.delete(key);
   }
 }
-
 
 /**
  * ProvingBackend
@@ -120,7 +129,11 @@ export interface VerifyingBackend {
    * @param artifacts The circuit artifacts (vkey, acir, etc).
    * @returns A boolean indicating if the proof is valid.
    */
-  verifyProof(proof: Uint8Array, publicInputs: string[], artifacts: any): Promise<boolean>;
+  verifyProof(
+    proof: Uint8Array,
+    publicInputs: string[],
+    artifacts: any,
+  ): Promise<boolean>;
 }
 
 /**
@@ -146,6 +159,10 @@ export interface PreparedWitness {
   fee: string;
 }
 
+export interface WitnessPreparationOptions {
+  merkleDepth?: number;
+}
+
 /**
  * ProofGenerator
  *
@@ -169,23 +186,34 @@ export class ProofGenerator {
   /**
    * Generates a proof using the configured backend.
    */
-  async generate(witness: any): Promise<Uint8Array> {
+  async generate(
+    witness: any,
+    options: WitnessPreparationOptions = {},
+  ): Promise<Uint8Array> {
     if (!this.backend) {
       throw new ProvingError(
-        'Proving backend not configured. Please provide a backend to the ProofGenerator.',
-        'BACKEND_ERROR'
+        "Proving backend not configured. Please provide a backend to the ProofGenerator.",
+        "BACKEND_ERROR",
       );
     }
     try {
-      assertValidPreparedWithdrawalWitness(witness);
+      assertValidPreparedWithdrawalWitness(witness, options);
     } catch (e: any) {
-      throw new ProvingError(`Invalid witness: ${e.message}`, 'WITNESS_ERROR', e);
+      throw new ProvingError(
+        `Invalid witness: ${e.message}`,
+        "WITNESS_ERROR",
+        e,
+      );
     }
 
     try {
       return await this.backend.generateProof(witness);
     } catch (e: any) {
-      throw new ProvingError(`Backend proof generation failed: ${e.message}`, 'BACKEND_ERROR', e);
+      throw new ProvingError(
+        `Backend proof generation failed: ${e.message}`,
+        "BACKEND_ERROR",
+        e,
+      );
     }
   }
 
@@ -204,40 +232,68 @@ export class ProofGenerator {
     merkleProof: MerkleProof,
     recipient: string,
     relayer: string = STELLAR_ZERO_ACCOUNT,
-    fee: bigint = 0n
+    fee: bigint = 0n,
+    options: WitnessPreparationOptions = {},
   ): Promise<PreparedWitness> {
-    if (
-      merkleProof.pathIndices !== undefined &&
-      merkleProof.pathIndices.length > 0 &&
-      merkleProof.pathIndices.length !== MERKLE_TREE_DEPTH
-    ) {
+    const expectedDepth = assertMerkleDepth(
+      options.merkleDepth ?? PRODUCTION_MERKLE_TREE_DEPTH,
+      "merkleDepth",
+    );
+
+    if (merkleProof.pathElements.length !== expectedDepth) {
       throw new WitnessValidationError(
-        `pathIndices length must equal tree depth ${MERKLE_TREE_DEPTH}, got ${merkleProof.pathIndices.length}`,
-        'MERKLE_PATH',
-        'structure'
+        `pathElements length must equal tree depth ${expectedDepth}, got ${merkleProof.pathElements.length}`,
+        "MERKLE_PATH",
+        "structure",
       );
     }
 
-    const rootField       = merkleNodeToField(merkleProof.root);
-    const nullifierField  = noteScalarToField(note.nullifier);
-    const secretField     = noteScalarToField(note.secret);
-    const poolIdField     = poolIdToField(note.poolId);
-    const nullifierHash   = computeNullifierHash(nullifierField, rootField);
-    const recipientField  = stellarAddressToField(recipient);
-    const relayerField    = fee === 0n ? ZERO_FIELD_HEX : stellarAddressToField(relayer);
+    if (
+      merkleProof.pathIndices !== undefined &&
+      merkleProof.pathIndices.length > 0 &&
+      merkleProof.pathIndices.length !== expectedDepth
+    ) {
+      throw new WitnessValidationError(
+        `pathIndices length must equal tree depth ${expectedDepth}, got ${merkleProof.pathIndices.length}`,
+        "MERKLE_PATH",
+        "structure",
+      );
+    }
+
+    const maxLeafIndex = merkleMaxLeafIndex(expectedDepth);
+    if (
+      !Number.isInteger(merkleProof.leafIndex) ||
+      merkleProof.leafIndex < 0 ||
+      merkleProof.leafIndex > maxLeafIndex
+    ) {
+      throw new WitnessValidationError(
+        `leafIndex out of range for tree depth (max ${maxLeafIndex})`,
+        "LEAF_INDEX",
+        "domain",
+      );
+    }
+
+    const rootField = merkleNodeToField(merkleProof.root);
+    const nullifierField = noteScalarToField(note.nullifier);
+    const secretField = noteScalarToField(note.secret);
+    const poolIdField = poolIdToField(note.poolId);
+    const nullifierHash = computeNullifierHash(nullifierField, rootField);
+    const recipientField = stellarAddressToField(recipient);
+    const relayerField =
+      fee === 0n ? ZERO_FIELD_HEX : stellarAddressToField(relayer);
 
     return {
-      nullifier:     nullifierField,
-      secret:        secretField,
-      leaf_index:    merkleProof.leafIndex.toString(),
-      hash_path:     merkleProof.pathElements.map((e) => merkleNodeToField(e)),
-      pool_id:       poolIdField,
-      root:          rootField,
+      nullifier: nullifierField,
+      secret: secretField,
+      leaf_index: merkleProof.leafIndex.toString(),
+      hash_path: merkleProof.pathElements.map((e) => merkleNodeToField(e)),
+      pool_id: poolIdField,
+      root: rootField,
       nullifier_hash: nullifierHash,
-      recipient:     recipientField,
-      amount:        note.amount.toString(),
-      relayer:       relayerField,
-      fee:           fee.toString(),
+      recipient: recipientField,
+      amount: note.amount.toString(),
+      relayer: relayerField,
+      fee: fee.toString(),
     };
   }
 
@@ -248,9 +304,13 @@ export class ProofGenerator {
   static formatProof(rawProof: Uint8Array): Buffer {
     // Soroban contract expects Proof struct: { a: BytesN<64>, b: BytesN<128>, c: BytesN<64> }
     try {
-      assertValidGroth16ProofBytes(rawProof, 'rawProof');
+      assertValidGroth16ProofBytes(rawProof, "rawProof");
     } catch (e: any) {
-      throw new ProvingError(`Invalid proof format from backend: ${e.message}`, 'FORMATTING_ERROR', e);
+      throw new ProvingError(
+        `Invalid proof format from backend: ${e.message}`,
+        "FORMATTING_ERROR",
+        e,
+      );
     }
     return Buffer.from(rawProof);
   }

--- a/sdk/src/withdraw.ts
+++ b/sdk/src/withdraw.ts
@@ -1,11 +1,24 @@
-import { Note } from './note';
-import { MerkleProof, PreparedWitness, ProofCache, ProofGenerator, ProvingBackend, VerifyingBackend } from './proof';
-import { BatchSyncResult, CommitmentLike, LocalMerkleTree, MerkleCheckpoint, syncCommitmentBatch } from './merkle';
-import { stableHash32, stableStringify } from './stable';
+import { Note } from "./note";
+import {
+  MerkleProof,
+  PreparedWitness,
+  ProofCache,
+  ProofGenerator,
+  ProvingBackend,
+  VerifyingBackend,
+} from "./proof";
+import {
+  BatchSyncResult,
+  CommitmentLike,
+  LocalMerkleTree,
+  MerkleCheckpoint,
+  syncCommitmentBatch,
+} from "./merkle";
+import { stableHash32, stableStringify } from "./stable";
 
 /**
  * WithdrawalRequest
- * 
+ *
  * Parameters for generating a withdrawal proof.
  */
 export interface WithdrawalRequest {
@@ -19,6 +32,7 @@ export interface WithdrawalRequest {
 export interface WithdrawalProofGenerationOptions {
   cache?: ProofCache;
   cacheKey?: string;
+  merkleDepth?: number;
 }
 
 interface WithdrawalCacheMaterial {
@@ -40,13 +54,16 @@ interface WithdrawalCacheMaterial {
   };
 }
 
-function buildCacheMaterial(request: WithdrawalRequest, witness: PreparedWitness): WithdrawalCacheMaterial {
+function buildCacheMaterial(
+  request: WithdrawalRequest,
+  witness: PreparedWitness,
+): WithdrawalCacheMaterial {
   return {
     note: {
       nullifier: witness.nullifier,
       secret: witness.secret,
       pool: request.note.poolId,
-      denomination: witness.amount
+      denomination: witness.amount,
     },
     root: witness.root,
     pool: request.note.poolId,
@@ -56,18 +73,18 @@ function buildCacheMaterial(request: WithdrawalRequest, witness: PreparedWitness
       recipient: witness.recipient,
       amount: witness.amount,
       relayer: witness.relayer,
-      fee: witness.fee
-    }
+      fee: witness.fee,
+    },
   };
 }
 
 export function buildWithdrawalProofCacheKey(
   request: WithdrawalRequest,
-  witness: PreparedWitness
+  witness: PreparedWitness,
 ): string {
   const material = buildCacheMaterial(request, witness);
   const canonical = stableStringify(material);
-  return `withdraw-proof:${stableHash32('withdraw-proof-cache-v1', canonical).toString('hex')}`;
+  return `withdraw-proof:${stableHash32("withdraw-proof-cache-v1", canonical).toString("hex")}`;
 }
 
 /**
@@ -76,21 +93,23 @@ export function buildWithdrawalProofCacheKey(
 export function syncWithdrawalTree(
   tree: LocalMerkleTree,
   commitments: CommitmentLike[],
-  checkpointOptions: { includeLeaves?: boolean } = {}
+  checkpointOptions: { includeLeaves?: boolean } = {},
 ): BatchSyncResult {
   return syncCommitmentBatch(tree, commitments, checkpointOptions);
 }
 
-export function restoreWithdrawalTree(checkpoint: MerkleCheckpoint): LocalMerkleTree {
+export function restoreWithdrawalTree(
+  checkpoint: MerkleCheckpoint,
+): LocalMerkleTree {
   return LocalMerkleTree.fromCheckpoint(checkpoint);
 }
 
 /**
  * generateWithdrawalProof
- * 
+ *
  * A stable API for generating a withdrawal proof across environments.
  * It abstracts the proving backend so that the SDK remains environment-agnostic.
- * 
+ *
  * @param request The withdrawal parameters.
  * @param backend The proving backend to use (e.g., Node or Browser Barretenberg).
  * @returns The formatted proof as a Buffer.
@@ -98,7 +117,7 @@ export function restoreWithdrawalTree(checkpoint: MerkleCheckpoint): LocalMerkle
 export async function generateWithdrawalProof(
   request: WithdrawalRequest,
   backend: ProvingBackend,
-  options: WithdrawalProofGenerationOptions = {}
+  options: WithdrawalProofGenerationOptions = {},
 ): Promise<Buffer> {
   const { note, merkleProof, recipient, relayer, fee } = request;
 
@@ -108,10 +127,12 @@ export async function generateWithdrawalProof(
     merkleProof,
     recipient,
     relayer,
-    fee
+    fee,
+    { merkleDepth: options.merkleDepth },
   );
 
-  const key = options.cacheKey ?? buildWithdrawalProofCacheKey(request, witness);
+  const key =
+    options.cacheKey ?? buildWithdrawalProofCacheKey(request, witness);
   if (options.cache) {
     const cached = await options.cache.get(key);
     if (cached) {
@@ -121,7 +142,9 @@ export async function generateWithdrawalProof(
 
   // 2. Generate the raw proof using the injected backend
   const proofGenerator = new ProofGenerator(backend);
-  const rawProof = await proofGenerator.generate(witness);
+  const rawProof = await proofGenerator.generate(witness, {
+    merkleDepth: options.merkleDepth,
+  });
 
   // 3. Format the proof for the Soroban contract
   const proof = ProofGenerator.formatProof(rawProof);
@@ -139,21 +162,21 @@ export async function generateWithdrawalProof(
  */
 export function extractPublicInputs(witness: PreparedWitness): string[] {
   return [
-    witness.pool_id,         // 0
-    witness.root,            // 1
-    witness.nullifier_hash,  // 2
-    witness.recipient,       // 3
-    witness.amount,          // 4
-    witness.relayer,         // 5
-    witness.fee,             // 6
+    witness.pool_id, // 0
+    witness.root, // 1
+    witness.nullifier_hash, // 2
+    witness.recipient, // 3
+    witness.amount, // 4
+    witness.relayer, // 5
+    witness.fee, // 6
   ];
 }
 
 /**
  * verifyWithdrawalProof
- * 
+ *
  * Verifies a withdrawal proof off-chain using circuit artifacts.
- * 
+ *
  * @param proof The proof bytes to verify.
  * @param publicInputs The public inputs used for the proof.
  * @param artifacts The circuit artifacts (vkey, etc).
@@ -163,7 +186,7 @@ export async function verifyWithdrawalProof(
   proof: Uint8Array,
   publicInputs: string[],
   artifacts: any,
-  backend: VerifyingBackend
+  backend: VerifyingBackend,
 ): Promise<boolean> {
   return backend.verifyProof(proof, publicInputs, artifacts);
 }

--- a/sdk/src/witness.ts
+++ b/sdk/src/witness.ts
@@ -1,21 +1,32 @@
-import { StrKey } from '@stellar/stellar-base';
-import { computeNullifierHash, hexToField } from './encoding';
-import type { PreparedWitness } from './proof';
-import { MERKLE_MAX_LEAF_INDEX, MERKLE_TREE_DEPTH } from './merkle';
-import { WitnessValidationError } from './errors';
-import { GROTH16_PROOF_BYTE_LENGTH as ZK_GROTH16_PROOF_BYTE_LENGTH, ZERO_FIELD_HEX } from './zk_constants';
+import { StrKey } from "@stellar/stellar-base";
+import { computeNullifierHash, hexToField } from "./encoding";
+import type { PreparedWitness } from "./proof";
+import {
+  MERKLE_TREE_DEPTH,
+  assertMerkleDepth,
+  merkleMaxLeafIndex,
+} from "./merkle";
+import { WitnessValidationError } from "./errors";
+import {
+  GROTH16_PROOF_BYTE_LENGTH as ZK_GROTH16_PROOF_BYTE_LENGTH,
+  ZERO_FIELD_HEX,
+} from "./zk_constants";
 
 const FIELD_HEX = /^[0-9a-fA-F]{64}$/;
 
 /** On-chain and SDK expectation for a Groth16 proof payload (A || B || C) for the withdrawal circuit. */
 export const GROTH16_PROOF_BYTE_LENGTH = ZK_GROTH16_PROOF_BYTE_LENGTH;
 
+export interface WitnessValidationOptions {
+  merkleDepth?: number;
+}
+
 function assertFieldHexString(value: string, publicName: string): void {
-  if (typeof value !== 'string' || !FIELD_HEX.test(value)) {
+  if (typeof value !== "string" || !FIELD_HEX.test(value)) {
     throw new WitnessValidationError(
       `${publicName} must be a 64-digit hex string (32-byte field)`,
-      'FIELD_ENCODING',
-      'structure'
+      "FIELD_ENCODING",
+      "structure",
     );
   }
   try {
@@ -23,26 +34,47 @@ function assertFieldHexString(value: string, publicName: string): void {
   } catch (e) {
     throw new WitnessValidationError(
       `${publicName} is not a valid field encoding: ${(e as Error).message}`,
-      'FIELD_ENCODING',
-      'structure'
+      "FIELD_ENCODING",
+      "structure",
     );
   }
 }
 
-function assertAmountFeeDecimal(amountStr: string, feeStr: string, amountLabel: string, feeLabel: string): { amount: bigint; fee: bigint } {
-  if (typeof amountStr !== 'string' || !/^\d+$/.test(amountStr)) {
-    throw new WitnessValidationError(`${amountLabel} must be a non-negative decimal string`, 'FIELD_ENCODING', 'structure');
+function assertAmountFeeDecimal(
+  amountStr: string,
+  feeStr: string,
+  amountLabel: string,
+  feeLabel: string,
+): { amount: bigint; fee: bigint } {
+  if (typeof amountStr !== "string" || !/^\d+$/.test(amountStr)) {
+    throw new WitnessValidationError(
+      `${amountLabel} must be a non-negative decimal string`,
+      "FIELD_ENCODING",
+      "structure",
+    );
   }
-  if (typeof feeStr !== 'string' || !/^\d+$/.test(feeStr)) {
-    throw new WitnessValidationError(`${feeLabel} must be a non-negative decimal string`, 'FIELD_ENCODING', 'structure');
+  if (typeof feeStr !== "string" || !/^\d+$/.test(feeStr)) {
+    throw new WitnessValidationError(
+      `${feeLabel} must be a non-negative decimal string`,
+      "FIELD_ENCODING",
+      "structure",
+    );
   }
   const amount = BigInt(amountStr);
   const fee = BigInt(feeStr);
   if (fee > amount) {
-    throw new WitnessValidationError('fee cannot exceed amount', 'WITNESS_SEMANTICS', 'domain');
+    throw new WitnessValidationError(
+      "fee cannot exceed amount",
+      "WITNESS_SEMANTICS",
+      "domain",
+    );
   }
   if (amount < 0n) {
-    throw new WitnessValidationError('amount must be non-negative', 'WITNESS_SEMANTICS', 'domain');
+    throw new WitnessValidationError(
+      "amount must be non-negative",
+      "WITNESS_SEMANTICS",
+      "domain",
+    );
   }
   return { amount, fee };
 }
@@ -50,12 +82,23 @@ function assertAmountFeeDecimal(amountStr: string, feeStr: string, amountLabel: 
 /**
  * Validates a Stellar G-strkey (Ed25519 account) before it is hashed into a field.
  */
-export function assertValidStellarAccountId(address: string, label: string = 'address'): void {
+export function assertValidStellarAccountId(
+  address: string,
+  label: string = "address",
+): void {
   if (address.length === 0) {
-    throw new WitnessValidationError(`${label} must be non-empty`, 'ADDRESS', 'structure');
+    throw new WitnessValidationError(
+      `${label} must be non-empty`,
+      "ADDRESS",
+      "structure",
+    );
   }
   if (!StrKey.isValidEd25519PublicKey(address)) {
-    throw new WitnessValidationError(`${label} is not a valid Stellar Ed25519 strkey`, 'ADDRESS', 'structure');
+    throw new WitnessValidationError(
+      `${label} is not a valid Stellar Ed25519 strkey`,
+      "ADDRESS",
+      "structure",
+    );
   }
 }
 
@@ -63,62 +106,90 @@ export function assertValidStellarAccountId(address: string, label: string = 'ad
  * Verifies a prepared witness object for structural safety and protocol consistency
  * (nullifier hash binding, fee / relayer rules) before a proving backend is invoked.
  */
-export function assertValidPreparedWithdrawalWitness(witness: PreparedWitness): void {
-  assertFieldHexString(witness.nullifier, 'nullifier');
-  assertFieldHexString(witness.secret, 'secret');
-  assertFieldHexString(witness.root, 'root');
-  assertFieldHexString(witness.nullifier_hash, 'nullifier_hash');
-  assertFieldHexString(witness.recipient, 'recipient');
-  assertFieldHexString(witness.relayer, 'relayer');
+export function assertValidPreparedWithdrawalWitness(
+  witness: PreparedWitness,
+  options: WitnessValidationOptions = {},
+): void {
+  const expectedDepth = assertMerkleDepth(
+    options.merkleDepth ?? MERKLE_TREE_DEPTH,
+    "merkleDepth",
+  );
+  const maxLeafIndex = merkleMaxLeafIndex(expectedDepth);
 
-  if (typeof witness.leaf_index !== 'string' || !/^\d+$/.test(witness.leaf_index)) {
-    throw new WitnessValidationError('leaf_index must be a non-negative integer string', 'LEAF_INDEX', 'structure');
+  assertFieldHexString(witness.nullifier, "nullifier");
+  assertFieldHexString(witness.secret, "secret");
+  assertFieldHexString(witness.root, "root");
+  assertFieldHexString(witness.nullifier_hash, "nullifier_hash");
+  assertFieldHexString(witness.recipient, "recipient");
+  assertFieldHexString(witness.relayer, "relayer");
+
+  if (
+    typeof witness.leaf_index !== "string" ||
+    !/^\d+$/.test(witness.leaf_index)
+  ) {
+    throw new WitnessValidationError(
+      "leaf_index must be a non-negative integer string",
+      "LEAF_INDEX",
+      "structure",
+    );
   }
   const leafIdx = Number(witness.leaf_index);
   if (!Number.isInteger(leafIdx) || leafIdx < 0) {
-    throw new WitnessValidationError('leaf_index must be a non-negative integer', 'LEAF_INDEX', 'structure');
-  }
-  if (leafIdx > MERKLE_MAX_LEAF_INDEX) {
     throw new WitnessValidationError(
-      `leafIndex out of range for tree depth (max ${MERKLE_MAX_LEAF_INDEX})`,
-      'LEAF_INDEX',
-      'domain'
+      "leaf_index must be a non-negative integer",
+      "LEAF_INDEX",
+      "structure",
+    );
+  }
+  if (leafIdx > maxLeafIndex) {
+    throw new WitnessValidationError(
+      `leafIndex out of range for tree depth (max ${maxLeafIndex})`,
+      "LEAF_INDEX",
+      "domain",
     );
   }
 
-  if (!Array.isArray(witness.hash_path) || witness.hash_path.length !== MERKLE_TREE_DEPTH) {
+  if (
+    !Array.isArray(witness.hash_path) ||
+    witness.hash_path.length !== expectedDepth
+  ) {
     throw new WitnessValidationError(
-      `hash_path must be an array of length ${MERKLE_TREE_DEPTH}`,
-      'MERKLE_PATH',
-      'structure'
+      `hash_path must be an array of length ${expectedDepth}`,
+      "MERKLE_PATH",
+      "structure",
     );
   }
   for (let i = 0; i < witness.hash_path.length; i++) {
     assertFieldHexString(witness.hash_path[i]!, `hash_path[${i}]`);
   }
 
-  const { fee } = assertAmountFeeDecimal(witness.amount, witness.fee, 'amount', 'fee');
+  const { fee } = assertAmountFeeDecimal(
+    witness.amount,
+    witness.fee,
+    "amount",
+    "fee",
+  );
   if (fee === 0n && witness.relayer !== ZERO_FIELD_HEX) {
     throw new WitnessValidationError(
-      'relayer must be the zero field when fee is zero (matches on-chain / circuit rules)',
-      'WITNESS_SEMANTICS',
-      'domain'
+      "relayer must be the zero field when fee is zero (matches on-chain / circuit rules)",
+      "WITNESS_SEMANTICS",
+      "domain",
     );
   }
   if (fee > 0n && witness.relayer === ZERO_FIELD_HEX) {
     throw new WitnessValidationError(
-      'relayer must be non-zero in the field when fee is non-zero',
-      'WITNESS_SEMANTICS',
-      'domain'
+      "relayer must be non-zero in the field when fee is non-zero",
+      "WITNESS_SEMANTICS",
+      "domain",
     );
   }
 
   const expectNh = computeNullifierHash(witness.nullifier, witness.root);
   if (expectNh !== witness.nullifier_hash) {
     throw new WitnessValidationError(
-      'nullifier_hash is inconsistent with (nullifier, root); possible cross-pool or replay issue',
-      'WITNESS_SEMANTICS',
-      'domain'
+      "nullifier_hash is inconsistent with (nullifier, root); possible cross-pool or replay issue",
+      "WITNESS_SEMANTICS",
+      "domain",
     );
   }
 }
@@ -126,12 +197,15 @@ export function assertValidPreparedWithdrawalWitness(witness: PreparedWitness): 
 /**
  * Fails on malformed **formatted** raw proof bytes before the verifier runs.
  */
-export function assertValidGroth16ProofBytes(proof: Uint8Array, label: string = 'proof'): void {
+export function assertValidGroth16ProofBytes(
+  proof: Uint8Array,
+  label: string = "proof",
+): void {
   if (proof.length !== GROTH16_PROOF_BYTE_LENGTH) {
     throw new WitnessValidationError(
       `${label} must be ${GROTH16_PROOF_BYTE_LENGTH} bytes, got ${proof.length}`,
-      'PROOF_FORMAT',
-      'structure'
+      "PROOF_FORMAT",
+      "structure",
     );
   }
 }

--- a/sdk/test/adversarial_invariants.test.ts
+++ b/sdk/test/adversarial_invariants.test.ts
@@ -1,76 +1,97 @@
-import fs from 'fs';
-import path from 'path';
-import { Note } from '../src/note';
-import { MerkleProof, ProofGenerator } from '../src/proof';
-import { computeNullifierHash, noteScalarToField, merkleNodeToField } from '../src/encoding';
-import { assertValidPreparedWithdrawalWitness } from '../src/witness';
-import { WitnessValidationError } from '../src/errors';
+import fs from "fs";
+import path from "path";
+import { Note } from "../src/note";
+import { MerkleProof, ProofGenerator } from "../src/proof";
+import {
+  computeNullifierHash,
+  noteScalarToField,
+  merkleNodeToField,
+} from "../src/encoding";
+import { assertValidPreparedWithdrawalWitness } from "../src/witness";
+import { WitnessValidationError } from "../src/errors";
 
-const G = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
-const V = path.join(__dirname, 'golden/vectors.json');
+const G = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const V = path.join(__dirname, "golden/vectors.json");
+const fixture = JSON.parse(fs.readFileSync(V, "utf8"));
+const OFFLINE_DEPTH = fixture.offline_tree_depth ?? 20;
 
 /**
  * Reusable invariants: nullifier–root cross-pool binding, public-input
  * replays, and nullifier hash uniqueness. Keeps the stack testable off-chain
  * without Soroban (see `circuits/withdraw/src/main.nr` for circuit mirrors).
  */
-describe('Adversarial invariants (privacy + spend safety)', () => {
-  it('rejects public-input swap: nullifier_hash from a different (nullifier, root) pair (replay)', async () => {
-    const fixture = JSON.parse(fs.readFileSync(V, 'utf8'));
-    const a = fixture.vectors.find((x: any) => x.id === 'TV-001');
-    const b = fixture.vectors.find((x: any) => x.id === 'TV-003');
+describe("Adversarial invariants (privacy + spend safety)", () => {
+  it("rejects public-input swap: nullifier_hash from a different (nullifier, root) pair (replay)", async () => {
+    const a = fixture.vectors.find((x: any) => x.id === "TV-001");
+    const b = fixture.vectors.find((x: any) => x.id === "TV-003");
     const note = new Note(
-      Buffer.from(a.note.nullifier_hex, 'hex'),
-      Buffer.from(a.note.secret_hex, 'hex'),
+      Buffer.from(a.note.nullifier_hex, "hex"),
+      Buffer.from(a.note.secret_hex, "hex"),
       a.note.pool_id,
-      BigInt(a.note.amount)
+      BigInt(a.note.amount),
     );
     const mp: MerkleProof = {
-      root: Buffer.from(a.merkle.root, 'hex'),
-      pathElements: a.merkle.path_elements.map((e: string) => Buffer.from(e, 'hex')),
-      pathIndices: Array(20).fill(0),
+      root: Buffer.from(a.merkle.root, "hex"),
+      pathElements: a.merkle.path_elements.map((e: string) =>
+        Buffer.from(e, "hex"),
+      ),
+      pathIndices: Array(OFFLINE_DEPTH).fill(0),
       leafIndex: a.merkle.leaf_index,
     };
-    const good = await ProofGenerator.prepareWitness(note, mp, G, G, 0n);
-    const otherNf = noteScalarToField(Buffer.from(b.note.nullifier_hex, 'hex'));
+    const good = await ProofGenerator.prepareWitness(note, mp, G, G, 0n, {
+      merkleDepth: OFFLINE_DEPTH,
+    });
+    const otherNf = noteScalarToField(Buffer.from(b.note.nullifier_hex, "hex"));
     const wrongReplay = computeNullifierHash(otherNf, good.root);
 
     const w = { ...good, nullifier_hash: wrongReplay };
     expect(good.nullifier).not.toBe(otherNf);
     expect(w.nullifier_hash).toBe(computeNullifierHash(otherNf, good.root));
     try {
-      assertValidPreparedWithdrawalWitness(w);
-      throw new Error('expected invalid witness');
+      assertValidPreparedWithdrawalWitness(w, { merkleDepth: OFFLINE_DEPTH });
+      throw new Error("expected invalid witness");
     } catch (e) {
       expect(e).toBeInstanceOf(WitnessValidationError);
     }
   });
 
-  it('cross-pool: same nullifier, different root fields yield different nullifier_hash (on-chain scoping)', () => {
-    const f = JSON.parse(fs.readFileSync(V, 'utf8'));
-    const t1 = f.vectors.find((x: any) => x.id === 'TV-001');
-    const t4 = f.vectors.find((x: any) => x.id === 'TV-004');
-    const nf = noteScalarToField(Buffer.from(t1.note.nullifier_hex, 'hex'));
-    const r1 = merkleNodeToField(Buffer.from(t1.merkle.root, 'hex'));
-    const r2 = merkleNodeToField(Buffer.from(t4.merkle.root, 'hex'));
+  it("cross-pool: same nullifier, different root fields yield different nullifier_hash (on-chain scoping)", () => {
+    const t1 = fixture.vectors.find((x: any) => x.id === "TV-001");
+    const t4 = fixture.vectors.find((x: any) => x.id === "TV-004");
+    const nf = noteScalarToField(Buffer.from(t1.note.nullifier_hex, "hex"));
+    const r1 = merkleNodeToField(Buffer.from(t1.merkle.root, "hex"));
+    const r2 = merkleNodeToField(Buffer.from(t4.merkle.root, "hex"));
     const h1 = computeNullifierHash(nf, r1);
     const h2 = computeNullifierHash(nf, r2);
     expect(h1).not.toBe(h2);
   });
 
-  it('two spends from different vectors cannot share nullifier_hash without sharing nullifier+root (golden)', () => {
-    const f = JSON.parse(fs.readFileSync(V, 'utf8'));
-    const t1 = f.vectors.find((x: any) => x.id === 'TV-001');
-    const t3 = f.vectors.find((x: any) => x.id === 'TV-003');
+  it("two spends from different vectors cannot share nullifier_hash without sharing nullifier+root (golden)", () => {
+    const t1 = fixture.vectors.find((x: any) => x.id === "TV-001");
+    const t3 = fixture.vectors.find((x: any) => x.id === "TV-003");
     expect(t1.nullifier_hash).not.toBe(t3.nullifier_hash);
   });
 });
 
-describe('Merkle proof surface (integration with pathIndices)', () => {
-  it('fails if pathIndices length is wrong when pathIndices is provided', () => {
-    const note = new Note(Buffer.from('01'.repeat(31), 'hex'), Buffer.from('02'.repeat(31), 'hex'), '03'.repeat(32), 1n);
-    const p = Buffer.from('aa'.repeat(32), 'hex');
-    const mp: MerkleProof = { root: p, pathElements: Array(20).fill(p), pathIndices: [0, 1, 2], leafIndex: 0 };
-    expect(ProofGenerator.prepareWitness(note, mp, G)).rejects.toThrow(WitnessValidationError);
+describe("Merkle proof surface (integration with pathIndices)", () => {
+  it("fails if pathIndices length is wrong when pathIndices is provided", () => {
+    const note = new Note(
+      Buffer.from("01".repeat(31), "hex"),
+      Buffer.from("02".repeat(31), "hex"),
+      "03".repeat(32),
+      1n,
+    );
+    const p = Buffer.from("aa".repeat(32), "hex");
+    const mp: MerkleProof = {
+      root: p,
+      pathElements: Array(OFFLINE_DEPTH).fill(p),
+      pathIndices: [0, 1, 2],
+      leafIndex: 0,
+    };
+    expect(
+      ProofGenerator.prepareWitness(note, mp, G, undefined, undefined, {
+        merkleDepth: OFFLINE_DEPTH,
+      }),
+    ).rejects.toThrow(WitnessValidationError);
   });
 });

--- a/sdk/test/golden/vectors.json
+++ b/sdk/test/golden/vectors.json
@@ -1,5 +1,7 @@
 {
   "version": 1,
+  "production_tree_depth": 20,
+  "offline_tree_depth": 20,
   "hash_algorithm": "SHA-256 (stand-in for BN254 Pedersen; regenerate with real prover)",
   "description": "PrivacyLayer end-to-end ZK path golden vectors. Covers note preimage → field encoding → nullifier hash → withdrawal public inputs. Used by SDK witness tests and circuit cross-stack fixtures.",
   "vectors": [

--- a/sdk/test/golden_vectors.test.ts
+++ b/sdk/test/golden_vectors.test.ts
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import path from 'path';
-import { Note, NoteBackupError } from '../src/note';
-import { MerkleProof, ProofGenerator } from '../src/proof';
+import fs from "fs";
+import path from "path";
+import { Note, NoteBackupError } from "../src/note";
+import { MerkleProof, ProofGenerator } from "../src/proof";
 import {
   noteScalarToField,
   merkleNodeToField,
@@ -10,14 +10,16 @@ import {
   packWithdrawalPublicInputs,
   stellarAddressToField,
   WITHDRAWAL_PUBLIC_INPUT_SCHEMA,
-} from '../src/encoding';
+} from "../src/encoding";
 
 // ---------------------------------------------------------------------------
 // Load golden fixture
 // ---------------------------------------------------------------------------
 
-const VECTORS_PATH = path.resolve(__dirname, 'golden/vectors.json');
-const fixture = JSON.parse(fs.readFileSync(VECTORS_PATH, 'utf8'));
+const VECTORS_PATH = path.resolve(__dirname, "golden/vectors.json");
+const fixture = JSON.parse(fs.readFileSync(VECTORS_PATH, "utf8"));
+const OFFLINE_DEPTH = fixture.offline_tree_depth ?? 20;
+const PRODUCTION_DEPTH = fixture.production_tree_depth ?? 20;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -25,18 +27,20 @@ const fixture = JSON.parse(fs.readFileSync(VECTORS_PATH, 'utf8'));
 
 function buildNote(v: any): Note {
   return new Note(
-    Buffer.from(v.note.nullifier_hex, 'hex'),
-    Buffer.from(v.note.secret_hex, 'hex'),
+    Buffer.from(v.note.nullifier_hex, "hex"),
+    Buffer.from(v.note.secret_hex, "hex"),
     v.note.pool_id,
-    BigInt(v.note.amount)
+    BigInt(v.note.amount),
   );
 }
 
 function buildMerkleProof(v: any): MerkleProof {
   return {
-    root: Buffer.from(v.merkle.root, 'hex'),
-    pathElements: v.merkle.path_elements.map((e: string) => Buffer.from(e, 'hex')),
-    pathIndices: Array(20).fill(0),
+    root: Buffer.from(v.merkle.root, "hex"),
+    pathElements: v.merkle.path_elements.map((e: string) =>
+      Buffer.from(e, "hex"),
+    ),
+    pathIndices: Array(OFFLINE_DEPTH).fill(0),
     leafIndex: v.merkle.leaf_index,
   };
 }
@@ -45,147 +49,181 @@ function buildMerkleProof(v: any): MerkleProof {
 // Golden vector corpus tests
 // ---------------------------------------------------------------------------
 
-describe('Golden Vector Corpus', () => {
-  it('fixture file loads and has the expected structure', () => {
+describe("Golden Vector Corpus", () => {
+  it("fixture file loads and has the expected structure", () => {
     expect(fixture.version).toBe(1);
+    expect(PRODUCTION_DEPTH).toBe(20);
+    expect(OFFLINE_DEPTH).toBeGreaterThan(0);
+    expect(OFFLINE_DEPTH).toBeLessThanOrEqual(PRODUCTION_DEPTH);
     expect(Array.isArray(fixture.vectors)).toBe(true);
     expect(fixture.vectors.length).toBeGreaterThanOrEqual(4);
   });
 
-  describe.each(fixture.vectors.map((v: any) => [v.id, v]) as [string, any][])('%s', (_id: string, v: any) => {
-    it('note scalars encode to canonical field hex', () => {
-      const nullifierField = noteScalarToField(Buffer.from(v.note.nullifier_hex, 'hex'));
-      const secretField = noteScalarToField(Buffer.from(v.note.secret_hex, 'hex'));
+  describe.each(fixture.vectors.map((v: any) => [v.id, v]) as [string, any][])(
+    "%s",
+    (_id: string, v: any) => {
+      it("note scalars encode to canonical field hex", () => {
+        const nullifierField = noteScalarToField(
+          Buffer.from(v.note.nullifier_hex, "hex"),
+        );
+        const secretField = noteScalarToField(
+          Buffer.from(v.note.secret_hex, "hex"),
+        );
 
-      expect(nullifierField).toBe(v.fields.nullifier);
-      expect(secretField).toBe(v.fields.secret);
-      expect(nullifierField).toHaveLength(64);
-      expect(secretField).toHaveLength(64);
-    });
+        expect(nullifierField).toBe(v.fields.nullifier);
+        expect(secretField).toBe(v.fields.secret);
+        expect(nullifierField).toHaveLength(64);
+        expect(secretField).toHaveLength(64);
+      });
 
-    it('merkle root encodes to canonical field hex', () => {
-      const rootField = merkleNodeToField(Buffer.from(v.merkle.root, 'hex'));
-      expect(rootField).toBe(v.public_inputs.root);
-      expect(rootField).toHaveLength(64);
-    });
+      it("merkle root encodes to canonical field hex", () => {
+        const rootField = merkleNodeToField(Buffer.from(v.merkle.root, "hex"));
+        expect(rootField).toBe(v.public_inputs.root);
+        expect(rootField).toHaveLength(64);
+      });
 
-    it('nullifier hash matches golden value', () => {
-      const nf = noteScalarToField(Buffer.from(v.note.nullifier_hex, 'hex'));
-      const root = merkleNodeToField(Buffer.from(v.merkle.root, 'hex'));
-      const nh = computeNullifierHash(nf, root);
+      it("nullifier hash matches golden value", () => {
+        const nf = noteScalarToField(Buffer.from(v.note.nullifier_hex, "hex"));
+        const root = merkleNodeToField(Buffer.from(v.merkle.root, "hex"));
+        const nh = computeNullifierHash(nf, root);
 
-      expect(nh).toBe(v.nullifier_hash);
-      expect(nh).toHaveLength(64);
-    });
+        expect(nh).toBe(v.nullifier_hash);
+        expect(nh).toHaveLength(64);
+      });
 
-    it('packed public inputs include pool_id first and match canonical schema order', () => {
-      const poolId    = poolIdToField(v.note.pool_id);
-      const root      = v.public_inputs.root;
-      const nh        = v.public_inputs.nullifier_hash;
-      const recipient = v.public_inputs.recipient;
-      const amount    = BigInt(v.public_inputs.amount);
-      const relayer   = v.public_inputs.relayer;
-      const fee       = BigInt(v.public_inputs.fee);
+      it("packed public inputs include pool_id first and match canonical schema order", () => {
+        const poolId = poolIdToField(v.note.pool_id);
+        const root = v.public_inputs.root;
+        const nh = v.public_inputs.nullifier_hash;
+        const recipient = v.public_inputs.recipient;
+        const amount = BigInt(v.public_inputs.amount);
+        const relayer = v.public_inputs.relayer;
+        const fee = BigInt(v.public_inputs.fee);
 
-      const packed = packWithdrawalPublicInputs(poolId, root, nh, recipient, amount, relayer, fee);
+        const packed = packWithdrawalPublicInputs(
+          poolId,
+          root,
+          nh,
+          recipient,
+          amount,
+          relayer,
+          fee,
+        );
 
-      expect(packed).toHaveLength(7);
-      expect(packed[0]).toBe(poolId);       // pool_id — first per schema
-      expect(packed[1]).toBe(root);
-      expect(packed[2]).toBe(nh);
-      expect(packed[3]).toBe(recipient);
-      expect(packed[4]).toBe(amount.toString());
-      expect(packed[5]).toBe(relayer);
-      expect(packed[6]).toBe(fee.toString()); // fee — last per schema
-    });
+        expect(packed).toHaveLength(7);
+        expect(packed[0]).toBe(poolId); // pool_id — first per schema
+        expect(packed[1]).toBe(root);
+        expect(packed[2]).toBe(nh);
+        expect(packed[3]).toBe(recipient);
+        expect(packed[4]).toBe(amount.toString());
+        expect(packed[5]).toBe(relayer);
+        expect(packed[6]).toBe(fee.toString()); // fee — last per schema
+      });
 
-    it('ProofGenerator.prepareWitness produces public inputs consistent with golden values', async () => {
-      const note = buildNote(v);
-      const merkleProof = buildMerkleProof(v);
+      it("ProofGenerator.prepareWitness produces public inputs consistent with golden values", async () => {
+        const note = buildNote(v);
+        const merkleProof = buildMerkleProof(v);
 
-      const relayerAddr =
-        v.public_inputs.fee === '0'
-          ? 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
-          : undefined;
+        const relayerAddr =
+          v.public_inputs.fee === "0"
+            ? "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+            : undefined;
 
-      const fee = BigInt(v.public_inputs.fee);
+        const fee = BigInt(v.public_inputs.fee);
 
-      const witness = await ProofGenerator.prepareWitness(note, merkleProof, v._recipient_addr ?? 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', relayerAddr, fee);
+        const witness = await ProofGenerator.prepareWitness(
+          note,
+          merkleProof,
+          v._recipient_addr ??
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          relayerAddr,
+          fee,
+          { merkleDepth: OFFLINE_DEPTH },
+        );
 
-      // Public inputs must match golden values
-      expect(witness.root).toBe(v.public_inputs.root);
-      expect(witness.nullifier_hash).toBe(v.public_inputs.nullifier_hash);
-      expect(witness.amount).toBe(v.public_inputs.amount);
-      expect(witness.fee).toBe(v.public_inputs.fee);
-      if (v.public_inputs.fee === '0') {
-        expect(witness.relayer).toBe(v.public_inputs.relayer);
-        expect(witness.relayer).toBe('0'.repeat(64));
-      }
+        // Public inputs must match golden values
+        expect(witness.root).toBe(v.public_inputs.root);
+        expect(witness.nullifier_hash).toBe(v.public_inputs.nullifier_hash);
+        expect(witness.amount).toBe(v.public_inputs.amount);
+        expect(witness.fee).toBe(v.public_inputs.fee);
+        if (v.public_inputs.fee === "0") {
+          expect(witness.relayer).toBe(v.public_inputs.relayer);
+          expect(witness.relayer).toBe("0".repeat(64));
+        }
 
-      // Private witnesses must match encoded note scalars
-      expect(witness.nullifier).toBe(v.fields.nullifier);
-      expect(witness.secret).toBe(v.fields.secret);
-      expect(witness.leaf_index).toBe(String(v.merkle.leaf_index));
-      expect(witness.hash_path).toHaveLength(20);
-    });
-  });
+        // Private witnesses must match encoded note scalars
+        expect(witness.nullifier).toBe(v.fields.nullifier);
+        expect(witness.secret).toBe(v.fields.secret);
+        expect(witness.leaf_index).toBe(String(v.merkle.leaf_index));
+        expect(witness.hash_path).toHaveLength(OFFLINE_DEPTH);
+      });
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
 // Note backup round-trip tests (Issue #300 cross-check)
 // ---------------------------------------------------------------------------
 
-describe('Note Backup Round-trip', () => {
-  describe.each(fixture.vectors.map((v: any) => [v.id, v]) as [string, any][])('%s backup round-trip', (_id: string, v: any) => {
-    it('exportBackup → importBackup produces identical note', () => {
-      const original = buildNote(v);
-      const backup = original.exportBackup();
+describe("Note Backup Round-trip", () => {
+  describe.each(fixture.vectors.map((v: any) => [v.id, v]) as [string, any][])(
+    "%s backup round-trip",
+    (_id: string, v: any) => {
+      it("exportBackup → importBackup produces identical note", () => {
+        const original = buildNote(v);
+        const backup = original.exportBackup();
 
-      expect(backup).toMatch(/^privacylayer-note:/);
+        expect(backup).toMatch(/^privacylayer-note:/);
 
-      const restored = Note.importBackup(backup);
+        const restored = Note.importBackup(backup);
 
-      expect(restored.nullifier).toEqual(original.nullifier);
-      expect(restored.secret).toEqual(original.secret);
-      expect(restored.poolId).toBe(original.poolId);
-      expect(restored.amount).toBe(original.amount);
-    });
-  });
+        expect(restored.nullifier).toEqual(original.nullifier);
+        expect(restored.secret).toEqual(original.secret);
+        expect(restored.poolId).toBe(original.poolId);
+        expect(restored.amount).toBe(original.amount);
+      });
+    },
+  );
 
-  it('importBackup throws INVALID_PREFIX for wrong prefix', () => {
-    expect(() => Note.importBackup('bad-prefix:deadbeef')).toThrow(NoteBackupError);
+  it("importBackup throws INVALID_PREFIX for wrong prefix", () => {
+    expect(() => Note.importBackup("bad-prefix:deadbeef")).toThrow(
+      NoteBackupError,
+    );
     try {
-      Note.importBackup('bad-prefix:deadbeef');
+      Note.importBackup("bad-prefix:deadbeef");
     } catch (e) {
-      expect((e as NoteBackupError).code).toBe('INVALID_PREFIX');
+      expect((e as NoteBackupError).code).toBe("INVALID_PREFIX");
     }
   });
 
-  it('importBackup throws INVALID_LENGTH for truncated payload', () => {
-    const short = 'privacylayer-note:' + 'ab'.repeat(50);
+  it("importBackup throws INVALID_LENGTH for truncated payload", () => {
+    const short = "privacylayer-note:" + "ab".repeat(50);
     try {
       Note.importBackup(short);
     } catch (e) {
-      expect((e as NoteBackupError).code).toBe('INVALID_LENGTH');
+      expect((e as NoteBackupError).code).toBe("INVALID_LENGTH");
     }
   });
 
-  it('importBackup throws CHECKSUM_MISMATCH for corrupted data', () => {
+  it("importBackup throws CHECKSUM_MISMATCH for corrupted data", () => {
     const original = buildNote(fixture.vectors[0]);
     const backup = original.exportBackup();
     // Flip a byte in the middle of the hex payload
-    const hex = backup.slice('privacylayer-note:'.length);
-    const flipped = hex.slice(0, 20) + (hex[20] === 'f' ? '0' : 'f') + hex.slice(21);
-    const corrupted = 'privacylayer-note:' + flipped;
+    const hex = backup.slice("privacylayer-note:".length);
+    const flipped =
+      hex.slice(0, 20) + (hex[20] === "f" ? "0" : "f") + hex.slice(21);
+    const corrupted = "privacylayer-note:" + flipped;
     try {
       Note.importBackup(corrupted);
     } catch (e) {
-      expect((e as NoteBackupError).code).toMatch(/CHECKSUM_MISMATCH|INVALID_LENGTH|CORRUPT_DATA/);
+      expect((e as NoteBackupError).code).toMatch(
+        /CHECKSUM_MISMATCH|INVALID_LENGTH|CORRUPT_DATA/,
+      );
     }
   });
 
-  it('random generated note survives backup round-trip', () => {
-    const note = Note.generate('aa'.repeat(32), 5_0000000n);
+  it("random generated note survives backup round-trip", () => {
+    const note = Note.generate("aa".repeat(32), 5_0000000n);
     const restored = Note.importBackup(note.exportBackup());
 
     expect(restored.nullifier).toEqual(note.nullifier);
@@ -199,39 +237,39 @@ describe('Note Backup Round-trip', () => {
 // Cross-stack fixture stability (regression guard)
 // ---------------------------------------------------------------------------
 
-describe('Cross-stack fixture stability', () => {
-  it('TV-001 nullifier hash is stable across runs', () => {
-    const v = fixture.vectors.find((x: any) => x.id === 'TV-001');
-    const nf = noteScalarToField(Buffer.from(v.note.nullifier_hex, 'hex'));
-    const root = merkleNodeToField(Buffer.from(v.merkle.root, 'hex'));
+describe("Cross-stack fixture stability", () => {
+  it("TV-001 nullifier hash is stable across runs", () => {
+    const v = fixture.vectors.find((x: any) => x.id === "TV-001");
+    const nf = noteScalarToField(Buffer.from(v.note.nullifier_hex, "hex"));
+    const root = merkleNodeToField(Buffer.from(v.merkle.root, "hex"));
     expect(computeNullifierHash(nf, root)).toBe(v.nullifier_hash);
   });
 
-  it('TV-004 sparse-tree vector produces distinct nullifier hash from TV-001', () => {
-    const v1 = fixture.vectors.find((x: any) => x.id === 'TV-001');
-    const v4 = fixture.vectors.find((x: any) => x.id === 'TV-004');
+  it("TV-004 sparse-tree vector produces distinct nullifier hash from TV-001", () => {
+    const v1 = fixture.vectors.find((x: any) => x.id === "TV-001");
+    const v4 = fixture.vectors.find((x: any) => x.id === "TV-004");
     expect(v4.nullifier_hash).not.toBe(v1.nullifier_hash);
   });
 
-  it('different notes produce different nullifier hashes even for same root', () => {
-    const v1 = fixture.vectors.find((x: any) => x.id === 'TV-001');
-    const v3 = fixture.vectors.find((x: any) => x.id === 'TV-003');
+  it("different notes produce different nullifier hashes even for same root", () => {
+    const v1 = fixture.vectors.find((x: any) => x.id === "TV-001");
+    const v3 = fixture.vectors.find((x: any) => x.id === "TV-003");
     // Both use leaf_index 0; their nullifiers differ so hashes must differ
     expect(v1.nullifier_hash).not.toBe(v3.nullifier_hash);
   });
 
-  it('same nullifier with different roots produces different nullifier hashes', () => {
+  it("same nullifier with different roots produces different nullifier hashes", () => {
     const v = fixture.vectors[0];
-    const nf = noteScalarToField(Buffer.from(v.note.nullifier_hex, 'hex'));
-    const root1 = '0'.repeat(63) + '1';
-    const root2 = '0'.repeat(63) + '2';
+    const nf = noteScalarToField(Buffer.from(v.note.nullifier_hex, "hex"));
+    const root1 = "0".repeat(63) + "1";
+    const root2 = "0".repeat(63) + "2";
     const nh1 = computeNullifierHash(nf, root1);
     const nh2 = computeNullifierHash(nf, root2);
     expect(nh1).not.toBe(nh2);
   });
 
-  it('stellarAddressToField is deterministic for the same address', () => {
-    const addr = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+  it("stellarAddressToField is deterministic for the same address", () => {
+    const addr = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
     expect(stellarAddressToField(addr)).toBe(stellarAddressToField(addr));
     expect(stellarAddressToField(addr)).toHaveLength(64);
   });
@@ -242,40 +280,67 @@ describe('Cross-stack fixture stability', () => {
 // These tests are golden: they must fail if anyone reorders the schema.
 // ---------------------------------------------------------------------------
 
-describe('Withdrawal public-input schema ordering (ZK-032)', () => {
-  it('schema has exactly 7 entries', () => {
+describe("Withdrawal public-input schema ordering (ZK-032)", () => {
+  it("schema has exactly 7 entries", () => {
     expect(WITHDRAWAL_PUBLIC_INPUT_SCHEMA).toHaveLength(7);
   });
 
-  it('schema order is stable — pool_id first, fee last', () => {
-    const expected = ['pool_id', 'root', 'nullifier_hash', 'recipient', 'amount', 'relayer', 'fee'];
+  it("schema order is stable — pool_id first, fee last", () => {
+    const expected = [
+      "pool_id",
+      "root",
+      "nullifier_hash",
+      "recipient",
+      "amount",
+      "relayer",
+      "fee",
+    ];
     expect(Array.from(WITHDRAWAL_PUBLIC_INPUT_SCHEMA)).toEqual(expected);
   });
 
-  it('packWithdrawalPublicInputs maps arguments to schema positions', () => {
-    const poolId = 'a'.repeat(64);
-    const root   = 'b'.repeat(64);
-    const nh     = 'c'.repeat(64);
-    const recip  = 'd'.repeat(64);
-    const relayer = 'e'.repeat(64);
-    const packed = packWithdrawalPublicInputs(poolId, root, nh, recip, 999n, relayer, 7n);
+  it("packWithdrawalPublicInputs maps arguments to schema positions", () => {
+    const poolId = "a".repeat(64);
+    const root = "b".repeat(64);
+    const nh = "c".repeat(64);
+    const recip = "d".repeat(64);
+    const relayer = "e".repeat(64);
+    const packed = packWithdrawalPublicInputs(
+      poolId,
+      root,
+      nh,
+      recip,
+      999n,
+      relayer,
+      7n,
+    );
 
-    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf('pool_id')]).toBe(poolId);
-    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf('root')]).toBe(root);
-    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf('nullifier_hash')]).toBe(nh);
-    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf('recipient')]).toBe(recip);
-    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf('amount')]).toBe('999');
-    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf('relayer')]).toBe(relayer);
-    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf('fee')]).toBe('7');
+    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf("pool_id")]).toBe(
+      poolId,
+    );
+    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf("root")]).toBe(root);
+    expect(
+      packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf("nullifier_hash")],
+    ).toBe(nh);
+    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf("recipient")]).toBe(
+      recip,
+    );
+    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf("amount")]).toBe(
+      "999",
+    );
+    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf("relayer")]).toBe(
+      relayer,
+    );
+    expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf("fee")]).toBe("7");
   });
 
-  it('prepareWitness public fields align with WITHDRAWAL_PUBLIC_INPUT_SCHEMA', async () => {
+  it("prepareWitness public fields align with WITHDRAWAL_PUBLIC_INPUT_SCHEMA", async () => {
     const v = fixture.vectors[0];
     const note = buildNote(v);
     const merkleProof = buildMerkleProof(v);
     const witness = await ProofGenerator.prepareWitness(
-      note, merkleProof,
-      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      note,
+      merkleProof,
+      "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
     );
 
     for (const key of WITHDRAWAL_PUBLIC_INPUT_SCHEMA) {

--- a/sdk/test/offline_depth.test.ts
+++ b/sdk/test/offline_depth.test.ts
@@ -1,0 +1,98 @@
+import { Note } from "../src/note";
+import { ProofGenerator } from "../src/proof";
+import {
+  LocalMerkleTree,
+  PRODUCTION_MERKLE_TREE_DEPTH,
+  generateMerkleFixtureVectors,
+} from "../src/merkle";
+import { generateWithdrawalProof } from "../src/withdraw";
+import { WitnessValidationError } from "../src/errors";
+import { GROTH16_PROOF_BYTE_LENGTH } from "../src/witness";
+
+const RECIPIENT = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const POOL_ID = "11".repeat(32);
+
+function buildNote(index: number): Note {
+  return Note.deriveDeterministic(
+    `fixture-${index}`,
+    POOL_ID,
+    1_000_000n + BigInt(index),
+  );
+}
+
+describe("Offline merkle depth support", () => {
+  it("can generate deterministic fixture vectors for miniature and production depths", () => {
+    const mini = generateMerkleFixtureVectors({
+      depth: 4,
+      leafCount: 6,
+      proveLeafIndices: [0, 3],
+    });
+    const prod = generateMerkleFixtureVectors({
+      depth: PRODUCTION_MERKLE_TREE_DEPTH,
+      leafCount: 4,
+      proveLeafIndices: [1],
+    });
+
+    expect(mini).toHaveLength(2);
+    expect(mini[0]?.depth).toBe(4);
+    expect(mini[0]?.pathElementsHex).toHaveLength(4);
+
+    expect(prod).toHaveLength(1);
+    expect(prod[0]?.depth).toBe(PRODUCTION_MERKLE_TREE_DEPTH);
+    expect(prod[0]?.pathElementsHex).toHaveLength(PRODUCTION_MERKLE_TREE_DEPTH);
+  });
+
+  it("requires explicit merkleDepth opt-in for miniature trees in witness preparation", async () => {
+    const depth = 4;
+    const tree = new LocalMerkleTree(depth);
+    const note = buildNote(0);
+    const leaf = note.getCommitment();
+    const leafIndex = tree.insert(leaf);
+    const proof = tree.generateProof(leafIndex);
+
+    await expect(
+      ProofGenerator.prepareWitness(note, proof, RECIPIENT),
+    ).rejects.toThrow(WitnessValidationError);
+
+    const witness = await ProofGenerator.prepareWitness(
+      note,
+      proof,
+      RECIPIENT,
+      undefined,
+      0n,
+      {
+        merkleDepth: depth,
+      },
+    );
+    expect(witness.hash_path).toHaveLength(depth);
+  });
+
+  it("generates proofs with miniature tree only when offline merkleDepth is provided", async () => {
+    const depth = 4;
+    const tree = new LocalMerkleTree(depth);
+    const note = buildNote(1);
+    const leafIndex = tree.insert(note.getCommitment());
+    const proof = tree.generateProof(leafIndex);
+
+    const backend = {
+      async generateProof() {
+        return new Uint8Array(GROTH16_PROOF_BYTE_LENGTH);
+      },
+    };
+
+    await expect(
+      generateWithdrawalProof(
+        { note, merkleProof: proof, recipient: RECIPIENT },
+        backend,
+      ),
+    ).rejects.toThrow(WitnessValidationError);
+
+    await expect(
+      generateWithdrawalProof(
+        { note, merkleProof: proof, recipient: RECIPIENT },
+        backend,
+        { merkleDepth: depth },
+      ),
+    ).resolves.toBeInstanceOf(Buffer);
+  });
+});

--- a/sdk/test/witness_mutation.test.ts
+++ b/sdk/test/witness_mutation.test.ts
@@ -1,26 +1,34 @@
-import fs from 'fs';
-import path from 'path';
-import { Note } from '../src/note';
-import { MerkleProof, PreparedWitness, ProofGenerator } from '../src/proof';
-import { assertValidPreparedWithdrawalWitness, assertValidGroth16ProofBytes, GROTH16_PROOF_BYTE_LENGTH } from '../src/witness';
-import { WitnessValidationError } from '../src/errors';
+import fs from "fs";
+import path from "path";
+import { Note } from "../src/note";
+import { MerkleProof, PreparedWitness, ProofGenerator } from "../src/proof";
+import {
+  assertValidPreparedWithdrawalWitness,
+  assertValidGroth16ProofBytes,
+  GROTH16_PROOF_BYTE_LENGTH,
+} from "../src/witness";
+import { WitnessValidationError } from "../src/errors";
 
-const VECTORS = path.join(__dirname, 'golden/vectors.json');
+const VECTORS = path.join(__dirname, "golden/vectors.json");
+const fixture = JSON.parse(fs.readFileSync(VECTORS, "utf8"));
+const OFFLINE_DEPTH = fixture.offline_tree_depth ?? 20;
 
 function buildNote(v: any): Note {
   return new Note(
-    Buffer.from(v.note.nullifier_hex, 'hex'),
-    Buffer.from(v.note.secret_hex, 'hex'),
+    Buffer.from(v.note.nullifier_hex, "hex"),
+    Buffer.from(v.note.secret_hex, "hex"),
     v.note.pool_id,
-    BigInt(v.note.amount)
+    BigInt(v.note.amount),
   );
 }
 
 function buildMerkle(v: any): MerkleProof {
   return {
-    root: Buffer.from(v.merkle.root, 'hex'),
-    pathElements: v.merkle.path_elements.map((e: string) => Buffer.from(e, 'hex')),
-    pathIndices: Array(20).fill(0),
+    root: Buffer.from(v.merkle.root, "hex"),
+    pathElements: v.merkle.path_elements.map((e: string) =>
+      Buffer.from(e, "hex"),
+    ),
+    pathIndices: Array(OFFLINE_DEPTH).fill(0),
     leafIndex: v.merkle.leaf_index,
   };
 }
@@ -29,88 +37,107 @@ function buildMerkle(v: any): MerkleProof {
  * Isolated single-dimension mutations from a known-good TV-001 witness.
  * Preserves one failure signature per case for refactors and debugging.
  */
-describe('Fixture mutation contract (one dimension per case)', () => {
-  const fixture = JSON.parse(fs.readFileSync(VECTORS, 'utf8'));
-  const v = fixture.vectors.find((x: any) => x.id === 'TV-001');
+describe("Fixture mutation contract (one dimension per case)", () => {
+  const v = fixture.vectors.find((x: any) => x.id === "TV-001");
 
   let good: PreparedWitness;
-  const recipient = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+  const recipient = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 
   beforeAll(async () => {
     const note = buildNote(v);
     const mp = buildMerkle(v);
-    good = await ProofGenerator.prepareWitness(note, mp, recipient, recipient, 0n);
+    good = await ProofGenerator.prepareWitness(
+      note,
+      mp,
+      recipient,
+      recipient,
+      0n,
+      { merkleDepth: OFFLINE_DEPTH },
+    );
   });
 
   function mustFailBinding(w: PreparedWitness, part: string) {
     try {
-      assertValidPreparedWithdrawalWitness(w);
+      assertValidPreparedWithdrawalWitness(w, { merkleDepth: OFFLINE_DEPTH });
       throw new Error(`expected failure for ${part}`);
     } catch (e) {
       expect(e).toBeInstanceOf(WitnessValidationError);
       const err = e as WitnessValidationError;
-      expect(err.code).toBe('WITNESS_SEMANTICS');
-      expect(err.reason).toBe('domain');
+      expect(err.code).toBe("WITNESS_SEMANTICS");
+      expect(err.reason).toBe("domain");
     }
   }
 
-  it('M_root: public root flips one hex digit (binding broken)', () => {
-    const w: PreparedWitness = { ...good, root: good.root.slice(0, 63) + (good.root[63] === '1' ? '0' : '1') };
-    mustFailBinding(w, 'root');
-  });
-
-  it('M_nullifier_hash: hash does not match (nullifier, root) pair', () => {
-    const w: PreparedWitness = { ...good, nullifier_hash: '1'.padStart(64, '0') };
-    mustFailBinding(w, 'nullifier_hash');
-  });
-
-  it('M_relayer: non-zero relayer field with zero fee', () => {
+  it("M_root: public root flips one hex digit (binding broken)", () => {
     const w: PreparedWitness = {
       ...good,
-      relayer: '1'.padStart(64, '0'),
+      root: good.root.slice(0, 63) + (good.root[63] === "1" ? "0" : "1"),
+    };
+    mustFailBinding(w, "root");
+  });
+
+  it("M_nullifier_hash: hash does not match (nullifier, root) pair", () => {
+    const w: PreparedWitness = {
+      ...good,
+      nullifier_hash: "1".padStart(64, "0"),
+    };
+    mustFailBinding(w, "nullifier_hash");
+  });
+
+  it("M_relayer: non-zero relayer field with zero fee", () => {
+    const w: PreparedWitness = {
+      ...good,
+      relayer: "1".padStart(64, "0"),
     };
     try {
-      assertValidPreparedWithdrawalWitness(w);
-      throw new Error('expected failure');
+      assertValidPreparedWithdrawalWitness(w, { merkleDepth: OFFLINE_DEPTH });
+      throw new Error("expected failure");
     } catch (e) {
       expect(e).toBeInstanceOf(WitnessValidationError);
       const err = e as WitnessValidationError;
-      expect(err.code).toBe('WITNESS_SEMANTICS');
+      expect(err.code).toBe("WITNESS_SEMANTICS");
     }
   });
 
-  it('M_fee: fee exceeds amount', () => {
-    const w: PreparedWitness = { ...good, fee: (BigInt(good.amount) + 1n).toString() };
-    mustFailBinding(w, 'fee>amount');
+  it("M_fee: fee exceeds amount", () => {
+    const w: PreparedWitness = {
+      ...good,
+      fee: (BigInt(good.amount) + 1n).toString(),
+    };
+    mustFailBinding(w, "fee>amount");
   });
 
-  it('M_leaf_index: out of range leaf index', () => {
-    const w: PreparedWitness = { ...good, leaf_index: '2000000' };
+  it("M_leaf_index: out of range leaf index", () => {
+    const w: PreparedWitness = { ...good, leaf_index: "2000000" };
     try {
-      assertValidPreparedWithdrawalWitness(w);
-      throw new Error('expected failure');
+      assertValidPreparedWithdrawalWitness(w, { merkleDepth: OFFLINE_DEPTH });
+      throw new Error("expected failure");
     } catch (e) {
       expect(e).toBeInstanceOf(WitnessValidationError);
       const err = e as WitnessValidationError;
-      expect(err.code).toBe('LEAF_INDEX');
+      expect(err.code).toBe("LEAF_INDEX");
     }
   });
 
-  it('M_hash_path: one sibling still passes binding but documents inclusion failure at circuit (semantics not checked here)', () => {
+  it("M_hash_path: one sibling still passes binding but documents inclusion failure at circuit (semantics not checked here)", () => {
     const path = good.hash_path.slice();
-    const flip = (path[0]![0] === '0' ? '1' : '0') + path[0]!.slice(1);
+    const flip = (path[0]![0] === "0" ? "1" : "0") + path[0]!.slice(1);
     path[0] = flip;
     const w: PreparedWitness = { ...good, hash_path: path };
-    assertValidPreparedWithdrawalWitness(w);
+    assertValidPreparedWithdrawalWitness(w, { merkleDepth: OFFLINE_DEPTH });
   });
 
-  it('M_format_proof: wrong length raw proof bytes (formatter boundary)', () => {
-    expect(() => assertValidGroth16ProofBytes(new Uint8Array(32))).toThrow(WitnessValidationError);
+  it("M_format_proof: wrong length raw proof bytes (formatter boundary)", () => {
+    expect(() => assertValidGroth16ProofBytes(new Uint8Array(32))).toThrow(
+      WitnessValidationError,
+    );
     const ok = new Uint8Array(GROTH16_PROOF_BYTE_LENGTH);
     expect(() => assertValidGroth16ProofBytes(ok)).not.toThrow();
   });
 
-  it('ProofGenerator.formatProof rejects under-long proof', () => {
-    expect(() => ProofGenerator.formatProof(new Uint8Array(1))).toThrow(WitnessValidationError);
+  it("ProofGenerator.formatProof rejects under-long proof", () => {
+    expect(() => ProofGenerator.formatProof(new Uint8Array(1))).toThrow(
+      WitnessValidationError,
+    );
   });
 });


### PR DESCRIPTION
## Wave Ticket

Wave Issue Key: `ZK-___`

Linked issue:
- Closes #264 
- Closes #270 
This pull request introduces a robust, explicit range check for Merkle tree leaf indices, ensuring that only values in [0, 2²⁰-1] are accepted throughout the Merkle circuit. The core improvement is a new `decompose_and_validate` function that decomposes the index into exactly 20 bits, checks for out-of-range values, and enforces round-trip correctness. This change eliminates subtle bugs from unchecked field arithmetic and strengthens circuit soundness. The update is reflected across the Merkle tree API, root computation, and test suites.

**Leaf Index Validation and Security**

* Added `decompose_and_validate` in `merkle/index.nr` to decompose the index into 20 bits, assert all higher bits are zero, and ensure round-trip reconstruction, providing deterministic rejection of out-of-range indices.
* Updated `merkle/root.nr` and `merkle/mod.nr` so all Merkle root computations and inclusion proofs use this strict bitwise validation, preventing unchecked field values from influencing tree traversal. [[1]](diffhunk://#diff-eda33bfb8d5b45502149a82ec167c40efdeb7bfa863f37caf2e6be30946c7d50R14-R32) [[2]](diffhunk://#diff-baba4fc8c8dca2ae234c1e103c890327d70009e4791a4da1117515db6fd40b71L21-L41) [[3]](diffhunk://#diff-f4447363c6eedaeb4b0ecee405788eda12489741fe475bf81c0bd5cee99c74c1L7-R20)

**API and Documentation Improvements**

* Improved documentation throughout the Merkle modules to clarify that indices are range-checked via explicit 20-bit decomposition, and described the security rationale in module-level and function-level comments. [[1]](diffhunk://#diff-baba4fc8c8dca2ae234c1e103c890327d70009e4791a4da1117515db6fd40b71L7-R12) [[2]](diffhunk://#diff-f4447363c6eedaeb4b0ecee405788eda12489741fe475bf81c0bd5cee99c74c1L7-R20)

**Testing and Coverage**

* Added comprehensive tests for valid and invalid indices in `merkle/index.nr`, including edge cases (0, max, just below/above max, high bit only, arbitrary values) and ensured assertion messages are clear and deterministic.
* Introduced new test cases in `circuits/merkle` and `circuits/withdraw` to verify that out-of-range indices are always rejected and boundary values are accepted, covering both direct and indirect (via withdrawal circuit) usage. [[1]](diffhunk://#diff-46fbd6c0c24a608418e57f6bc2b424683fdb58ed6e7970da3f959663de079ad3R221-R259) [[2]](diffhunk://#diff-f449b281948cf2d00f4a6e20b2f785d07ac3646939006fa8b1dd032dd6a6b4a9R329-R421)

**Code Cleanup and Organization**

* Removed redundant or now-unnecessary validation logic and updated test module imports for clarity and maintainability. [[1]](diffhunk://#diff-8b7f2cba325764300b50873828348ba238c27f98f8df2124ac624a3c2945d45dL24) [[2]](diffhunk://#diff-c85cb8ec25f1d4f6021c687f2e0270bf4f16ee60877a2165c0caeae31c4b9769L56-R60) [[3]](diffhunk://#diff-b4e660407109986daa88ec272a374927ba6efe14932c45202fb6b9dcd3be279bL32-R36)

**Minor Fixes**

* Minor code style and type consistency improvements, such as explicit casting in loops and consistent use of bit types.

These changes collectively ensure that Merkle tree operations are sound, predictable, and resistant to subtle bugs or attacks involving out-of-range indices.

## What Changed

- 

## Validation

- [ ] I linked the ZK ticket key above.
- [ ] I ran `node scripts/zk_ticket_check.mjs --issue-key ZK-___`.
- [ ] I ran the derived checks locally for the ticket I am implementing.
- [ ] I updated tests or fixtures when the ticket changed circuit or witness behavior.

Validation output:

```text
paste the command output here
```
