### PR TITLE
feat(sdk): strict verifier encoding and privacy payload boundaries

### DIFF
--- a/circuits/TEST_VECTORS.md
+++ b/circuits/TEST_VECTORS.md
@@ -192,7 +192,12 @@ Each vector captures:
 4. **Nullifier hash** — `H(nullifier_field, root_field)` using the same algorithm
    as the circuit (`compute_nullifier_hash` in `circuits/lib/src/hash/nullifier.nr`)
 5. **Packed public inputs** — ordered as the circuit entrypoint expects:
-   `root | nullifier_hash | recipient | amount | relayer | fee`
+   `pool_id | root | nullifier_hash | recipient | amount | relayer | fee`
+
+The corpus intentionally does **not** embed portable note backup strings, legacy
+serialized note strings, full prepared witness payloads, or cache-helper blobs.
+Tests reconstruct those from the minimal fixture fields when needed so the vector
+file remains useful without normalizing extra note metadata into exported artifacts.
 
 > **Hash note**: The SDK currently uses SHA-256 as a structural stand-in for BN254
 > Pedersen.  When `@noir-lang/barretenberg` (or equivalent) is wired in, regenerate

--- a/sdk/src/encoding.ts
+++ b/sdk/src/encoding.ts
@@ -133,6 +133,73 @@ export const WITHDRAWAL_PUBLIC_INPUT_SCHEMA = [
 ] as const;
 
 export type WithdrawalPublicInputKey = (typeof WITHDRAWAL_PUBLIC_INPUT_SCHEMA)[number];
+export type WithdrawalPublicInputs = Record<WithdrawalPublicInputKey, string>;
+
+export interface SerializedWithdrawalPublicInputs {
+  values: WithdrawalPublicInputs;
+  fields: string[];
+  bytes: Buffer;
+}
+
+function assertCanonicalFieldHex(value: string, label: WithdrawalPublicInputKey): string {
+  const clean = value.startsWith('0x') ? value.slice(2) : value;
+  if (!/^[0-9a-fA-F]{64}$/.test(clean)) {
+    throw new Error(`${label} must be a 64-digit hex string`);
+  }
+  return clean.toLowerCase();
+}
+
+function assertCanonicalFieldDecimal(value: string, label: WithdrawalPublicInputKey): bigint {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${label} must be a non-negative decimal string`);
+  }
+  return BigInt(value);
+}
+
+function encodeWithdrawalPublicInputValue(
+  key: WithdrawalPublicInputKey,
+  value: string
+): Buffer {
+  switch (key) {
+    case 'amount':
+    case 'fee':
+      return fieldToBuffer(assertCanonicalFieldDecimal(value, key));
+    default:
+      return Buffer.from(assertCanonicalFieldHex(value, key), 'hex');
+  }
+}
+
+export function collectWithdrawalPublicInputs(
+  source: WithdrawalPublicInputs
+): WithdrawalPublicInputs {
+  const values = {} as WithdrawalPublicInputs;
+
+  for (const key of WITHDRAWAL_PUBLIC_INPUT_SCHEMA) {
+    const value = source[key];
+    if (typeof value !== 'string') {
+      throw new Error(`Missing public input: ${key}`);
+    }
+    values[key] = value;
+  }
+
+  return values;
+}
+
+/**
+ * Serialize the named withdrawal public inputs into the exact canonical
+ * field order and 32-byte big-endian byte layout consumed by verifier boundaries.
+ */
+export function serializeWithdrawalPublicInputs(
+  source: WithdrawalPublicInputs
+): SerializedWithdrawalPublicInputs {
+  const values = collectWithdrawalPublicInputs(source);
+  const fields = WITHDRAWAL_PUBLIC_INPUT_SCHEMA.map((key) => values[key]);
+  const bytes = Buffer.concat(
+    WITHDRAWAL_PUBLIC_INPUT_SCHEMA.map((key) => encodeWithdrawalPublicInputValue(key, values[key]))
+  );
+
+  return { values, fields, bytes };
+}
 
 /**
  * Pack the public inputs of the withdrawal circuit in the canonical order
@@ -149,5 +216,13 @@ export function packWithdrawalPublicInputs(
   relayer: string,
   fee: bigint
 ): string[] {
-  return [poolId, root, nullifierHash, recipient, amount.toString(), relayer, fee.toString()];
+  return serializeWithdrawalPublicInputs({
+    pool_id: poolId,
+    root,
+    nullifier_hash: nullifierHash,
+    recipient,
+    amount: amount.toString(),
+    relayer,
+    fee: fee.toString(),
+  }).fields;
 }

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -13,6 +13,7 @@ export class WitnessValidationError extends Error {
       | 'FIELD_ENCODING'
       | 'ADDRESS'
       | 'WITNESS_SEMANTICS'
+      | 'PUBLIC_INPUT_SCHEMA'
       | 'PROOF_FORMAT',
     public readonly reason?: 'structure' | 'domain'
   ) {

--- a/sdk/src/merkle.ts
+++ b/sdk/src/merkle.ts
@@ -17,6 +17,12 @@ export interface MerkleCheckpoint {
   leaves?: string[];
 }
 
+export interface BatchSyncResult {
+  insertedLeafIndices: number[];
+  checkpoint: MerkleCheckpoint;
+  root: Buffer;
+}
+
 function toLeaf(commitment: CommitmentLike): Buffer {
   if (Buffer.isBuffer(commitment) || commitment instanceof Uint8Array) {
     const bytes = Buffer.from(commitment);

--- a/sdk/src/note.ts
+++ b/sdk/src/note.ts
@@ -7,6 +7,12 @@ import {
   NOTE_SCALAR_BYTE_LENGTH,
 } from './zk_constants';
 
+const HEX_PAYLOAD = /^[0-9a-fA-F]+$/;
+const POOL_ID_HEX = /^[0-9a-fA-F]{64}$/;
+const LEGACY_NOTE_PREFIX = 'privacylayer-note-';
+const LEGACY_NOTE_PAYLOAD_LENGTH = NOTE_SCALAR_BYTE_LENGTH + NOTE_SCALAR_BYTE_LENGTH + 32 + 16;
+const MAX_NOTE_AMOUNT = (1n << 64n) - 1n;
+
 type CryptoLike = {
   getRandomValues<T extends ArrayBufferView | null>(array: T): T;
 };
@@ -105,6 +111,12 @@ export class Note {
     if (nullifier.length !== NOTE_SCALAR_BYTE_LENGTH || secret.length !== NOTE_SCALAR_BYTE_LENGTH) {
       throw new Error(`Nullifier and secret must be ${NOTE_SCALAR_BYTE_LENGTH} bytes to fit BN254 field`);
     }
+    if (!POOL_ID_HEX.test(poolId)) {
+      throw new Error('Pool ID must be exactly 32 bytes encoded as 64 hex characters');
+    }
+    if (amount < 0n || amount > MAX_NOTE_AMOUNT) {
+      throw new Error(`Note amount must fit within an unsigned 64-bit integer, got ${amount}`);
+    }
   }
 
   /**
@@ -195,6 +207,16 @@ export class Note {
     }
 
     const hex = backup.slice(NOTE_BACKUP_PREFIX.length);
+    if (!HEX_PAYLOAD.test(hex)) {
+      throw new NoteBackupError('Note backup contains invalid hex data', 'CORRUPT_DATA');
+    }
+    if (hex.length !== NOTE_BACKUP_PAYLOAD_LENGTH * 2) {
+      throw new NoteBackupError(
+        `Note backup payload must be ${NOTE_BACKUP_PAYLOAD_LENGTH} bytes, got ${Math.floor(hex.length / 2)}`,
+        'INVALID_LENGTH'
+      );
+    }
+
     let payload: Buffer;
     try {
       payload = Buffer.from(hex, 'hex');
@@ -250,17 +272,20 @@ export class Note {
       Buffer.alloc(16), // amount padding
     ]);
     data.writeBigUInt64BE(this.amount, 31 + 31 + 32);
-    return `privacylayer-note-${data.toString('hex')}`;
+    return LEGACY_NOTE_PREFIX + data.toString('hex');
   }
 
   /**
    * @deprecated Use `Note.importBackup` for new code.
    */
   static deserialize(noteStr: string): Note {
-    if (!noteStr.startsWith('privacylayer-note-')) {
+    if (!noteStr.startsWith(LEGACY_NOTE_PREFIX)) {
       throw new Error('Invalid note format');
     }
-    const hex = noteStr.replace('privacylayer-note-', '');
+    const hex = noteStr.slice(LEGACY_NOTE_PREFIX.length);
+    if (!HEX_PAYLOAD.test(hex) || hex.length !== LEGACY_NOTE_PAYLOAD_LENGTH * 2) {
+      throw new Error('Invalid note format');
+    }
     const data = Buffer.from(hex, 'hex');
 
     const nullifier = data.subarray(0, 31);

--- a/sdk/src/proof.ts
+++ b/sdk/src/proof.ts
@@ -1,9 +1,11 @@
 import { Note } from './note';
 import {
+  WithdrawalPublicInputs,
   merkleNodeToField,
   noteScalarToField,
   poolIdToField,
   computeNullifierHash,
+  serializeWithdrawalPublicInputs,
   stellarAddressToField,
 } from './encoding';
 import { WitnessValidationError } from './errors';
@@ -43,6 +45,7 @@ export interface MerkleProof {
 export interface Groth16Proof {
   proof: Uint8Array;
   publicInputs: string[];
+  publicInputBytes: Uint8Array;
 }
 
 /**
@@ -146,6 +149,36 @@ export interface PreparedWitness {
   fee: string;
 }
 
+export const PREPARED_WITHDRAWAL_WITNESS_SCHEMA = [
+  'nullifier',
+  'secret',
+  'leaf_index',
+  'hash_path',
+  'pool_id',
+  'root',
+  'nullifier_hash',
+  'recipient',
+  'amount',
+  'relayer',
+  'fee',
+] as const;
+
+function canonicalizePreparedWitness(witness: PreparedWitness): PreparedWitness {
+  return {
+    nullifier: witness.nullifier,
+    secret: witness.secret,
+    leaf_index: witness.leaf_index,
+    hash_path: witness.hash_path.map((entry) => entry),
+    pool_id: witness.pool_id,
+    root: witness.root,
+    nullifier_hash: witness.nullifier_hash,
+    recipient: witness.recipient,
+    amount: witness.amount,
+    relayer: witness.relayer,
+    fee: witness.fee,
+  };
+}
+
 /**
  * ProofGenerator
  *
@@ -183,7 +216,7 @@ export class ProofGenerator {
     }
 
     try {
-      return await this.backend.generateProof(witness);
+      return await this.backend.generateProof(canonicalizePreparedWitness(witness));
     } catch (e: any) {
       throw new ProvingError(`Backend proof generation failed: ${e.message}`, 'BACKEND_ERROR', e);
     }
@@ -245,13 +278,38 @@ export class ProofGenerator {
    * Formats a raw proof from Noir/Barretenberg into the format
    * expected by the Soroban contract.
    */
-  static formatProof(rawProof: Uint8Array): Buffer {
-    // Soroban contract expects Proof struct: { a: BytesN<64>, b: BytesN<128>, c: BytesN<64> }
+  static formatProofPayload(
+    rawProof: Uint8Array,
+    publicInputs: WithdrawalPublicInputs
+  ): Groth16Proof {
     try {
       assertValidGroth16ProofBytes(rawProof, 'rawProof');
     } catch (e: any) {
       throw new ProvingError(`Invalid proof format from backend: ${e.message}`, 'FORMATTING_ERROR', e);
     }
-    return Buffer.from(rawProof);
+
+    try {
+      const serialized = serializeWithdrawalPublicInputs(publicInputs);
+      return {
+        proof: Buffer.from(rawProof),
+        publicInputs: serialized.fields,
+        publicInputBytes: serialized.bytes,
+      };
+    } catch (e: any) {
+      throw new ProvingError(
+        `Invalid withdrawal public-input schema: ${e.message}`,
+        'FORMATTING_ERROR',
+        e
+      );
+    }
+  }
+
+  /**
+   * Formats a raw proof from Noir/Barretenberg into the proof bytes
+   * expected by the Soroban contract.
+   */
+  static formatProof(rawProof: Uint8Array, publicInputs: WithdrawalPublicInputs): Buffer {
+    // Soroban contract expects Proof struct: { a: BytesN<64>, b: BytesN<128>, c: BytesN<64> }
+    return Buffer.from(this.formatProofPayload(rawProof, publicInputs).proof);
   }
 }

--- a/sdk/src/withdraw.ts
+++ b/sdk/src/withdraw.ts
@@ -1,7 +1,13 @@
 import { Note } from './note';
 import { MerkleProof, PreparedWitness, ProofCache, ProofGenerator, ProvingBackend, VerifyingBackend } from './proof';
 import { BatchSyncResult, CommitmentLike, LocalMerkleTree, MerkleCheckpoint, syncCommitmentBatch } from './merkle';
+import {
+  SerializedWithdrawalPublicInputs,
+  WithdrawalPublicInputs,
+  serializeWithdrawalPublicInputs,
+} from './encoding';
 import { stableHash32, stableStringify } from './stable';
+import { WitnessValidationError } from './errors';
 
 /**
  * WithdrawalRequest
@@ -22,50 +28,34 @@ export interface WithdrawalProofGenerationOptions {
 }
 
 interface WithdrawalCacheMaterial {
-  note: {
+  privateInputs: {
     nullifier: string;
     secret: string;
-    pool: string;
-    denomination: string;
+    leaf_index: string;
+    hash_path: string[];
   };
-  root: string;
-  pool: string;
-  publicInputs: {
-    root: string;
-    nullifier_hash: string;
-    recipient: string;
-    amount: string;
-    relayer: string;
-    fee: string;
-  };
+  publicInputs: WithdrawalPublicInputs;
 }
 
-function buildCacheMaterial(request: WithdrawalRequest, witness: PreparedWitness): WithdrawalCacheMaterial {
+function buildCacheMaterial(witness: PreparedWitness): WithdrawalCacheMaterial {
+  const serialized = serializeWithdrawalPublicInputs(witness);
+
   return {
-    note: {
+    privateInputs: {
       nullifier: witness.nullifier,
       secret: witness.secret,
-      pool: request.note.poolId,
-      denomination: witness.amount
+      leaf_index: witness.leaf_index,
+      hash_path: witness.hash_path.slice(),
     },
-    root: witness.root,
-    pool: request.note.poolId,
-    publicInputs: {
-      root: witness.root,
-      nullifier_hash: witness.nullifier_hash,
-      recipient: witness.recipient,
-      amount: witness.amount,
-      relayer: witness.relayer,
-      fee: witness.fee
-    }
+    publicInputs: serialized.values
   };
 }
 
 export function buildWithdrawalProofCacheKey(
-  request: WithdrawalRequest,
+  _request: WithdrawalRequest,
   witness: PreparedWitness
 ): string {
-  const material = buildCacheMaterial(request, witness);
+  const material = buildCacheMaterial(witness);
   const canonical = stableStringify(material);
   return `withdraw-proof:${stableHash32('withdraw-proof-cache-v1', canonical).toString('hex')}`;
 }
@@ -83,6 +73,24 @@ export function syncWithdrawalTree(
 
 export function restoreWithdrawalTree(checkpoint: MerkleCheckpoint): LocalMerkleTree {
   return LocalMerkleTree.fromCheckpoint(checkpoint);
+}
+
+function assertNamedWithdrawalPublicInputs(
+  publicInputs: WithdrawalPublicInputs | PreparedWitness | string[]
+): asserts publicInputs is WithdrawalPublicInputs | PreparedWitness {
+  if (Array.isArray(publicInputs)) {
+    throw new WitnessValidationError(
+      'Public inputs must be provided as named fields so canonical schema order can be enforced',
+      'PUBLIC_INPUT_SCHEMA',
+      'structure'
+    );
+  }
+}
+
+export function buildWithdrawalPublicInputLayout(
+  publicInputs: WithdrawalPublicInputs | PreparedWitness
+): SerializedWithdrawalPublicInputs {
+  return serializeWithdrawalPublicInputs(publicInputs);
 }
 
 /**
@@ -124,7 +132,7 @@ export async function generateWithdrawalProof(
   const rawProof = await proofGenerator.generate(witness);
 
   // 3. Format the proof for the Soroban contract
-  const proof = ProofGenerator.formatProof(rawProof);
+  const proof = ProofGenerator.formatProof(rawProof, buildWithdrawalPublicInputLayout(witness).values);
   if (options.cache) {
     await options.cache.set(key, proof);
   }
@@ -138,15 +146,7 @@ export async function generateWithdrawalProof(
  * defined by WITHDRAWAL_PUBLIC_INPUT_SCHEMA (pool_id … fee).
  */
 export function extractPublicInputs(witness: PreparedWitness): string[] {
-  return [
-    witness.pool_id,         // 0
-    witness.root,            // 1
-    witness.nullifier_hash,  // 2
-    witness.recipient,       // 3
-    witness.amount,          // 4
-    witness.relayer,         // 5
-    witness.fee,             // 6
-  ];
+  return buildWithdrawalPublicInputLayout(witness).fields;
 }
 
 /**
@@ -161,9 +161,10 @@ export function extractPublicInputs(witness: PreparedWitness): string[] {
  */
 export async function verifyWithdrawalProof(
   proof: Uint8Array,
-  publicInputs: string[],
+  publicInputs: WithdrawalPublicInputs | PreparedWitness | string[],
   artifacts: any,
   backend: VerifyingBackend
 ): Promise<boolean> {
-  return backend.verifyProof(proof, publicInputs, artifacts);
+  assertNamedWithdrawalPublicInputs(publicInputs);
+  return backend.verifyProof(proof, buildWithdrawalPublicInputLayout(publicInputs).fields, artifacts);
 }

--- a/sdk/src/witness.ts
+++ b/sdk/src/witness.ts
@@ -64,6 +64,7 @@ export function assertValidStellarAccountId(address: string, label: string = 'ad
  * (nullifier hash binding, fee / relayer rules) before a proving backend is invoked.
  */
 export function assertValidPreparedWithdrawalWitness(witness: PreparedWitness): void {
+  assertFieldHexString(witness.pool_id, 'pool_id');
   assertFieldHexString(witness.nullifier, 'nullifier');
   assertFieldHexString(witness.secret, 'secret');
   assertFieldHexString(witness.root, 'root');

--- a/sdk/test/golden_vectors.test.ts
+++ b/sdk/test/golden_vectors.test.ts
@@ -8,9 +8,11 @@ import {
   poolIdToField,
   computeNullifierHash,
   packWithdrawalPublicInputs,
+  serializeWithdrawalPublicInputs,
   stellarAddressToField,
   WITHDRAWAL_PUBLIC_INPUT_SCHEMA,
 } from '../src/encoding';
+import { buildWithdrawalPublicInputLayout } from '../src/withdraw';
 
 // ---------------------------------------------------------------------------
 // Load golden fixture
@@ -269,6 +271,37 @@ describe('Withdrawal public-input schema ordering (ZK-032)', () => {
     expect(packed[WITHDRAWAL_PUBLIC_INPUT_SCHEMA.indexOf('fee')]).toBe('7');
   });
 
+  it('serializeWithdrawalPublicInputs emits canonical verifier byte order', () => {
+    const serialized = serializeWithdrawalPublicInputs({
+      pool_id: 'aa'.repeat(32),
+      root: 'bb'.repeat(32),
+      nullifier_hash: 'cc'.repeat(32),
+      recipient: 'dd'.repeat(32),
+      amount: '999',
+      relayer: 'ee'.repeat(32),
+      fee: '7',
+    });
+
+    expect(serialized.fields).toEqual([
+      'aa'.repeat(32),
+      'bb'.repeat(32),
+      'cc'.repeat(32),
+      'dd'.repeat(32),
+      '999',
+      'ee'.repeat(32),
+      '7',
+    ]);
+    expect(serialized.bytes.toString('hex')).toBe([
+      'aa'.repeat(32),
+      'bb'.repeat(32),
+      'cc'.repeat(32),
+      'dd'.repeat(32),
+      '0'.repeat(61) + '3e7',
+      'ee'.repeat(32),
+      '0'.repeat(63) + '7',
+    ].join(''));
+  });
+
   it('prepareWitness public fields align with WITHDRAWAL_PUBLIC_INPUT_SCHEMA', async () => {
     const v = fixture.vectors[0];
     const note = buildNote(v);
@@ -281,5 +314,22 @@ describe('Withdrawal public-input schema ordering (ZK-032)', () => {
     for (const key of WITHDRAWAL_PUBLIC_INPUT_SCHEMA) {
       expect(witness).toHaveProperty(key);
     }
+  });
+
+  it('buildWithdrawalPublicInputLayout uses witness fields in schema order', async () => {
+    const v = fixture.vectors[0];
+    const note = buildNote(v);
+    const merkleProof = buildMerkleProof(v);
+    const witness = await ProofGenerator.prepareWitness(
+      note,
+      merkleProof,
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    );
+
+    const layout = buildWithdrawalPublicInputLayout(witness);
+
+    expect(layout.values.pool_id).toBe(witness.pool_id);
+    expect(layout.fields).toEqual(WITHDRAWAL_PUBLIC_INPUT_SCHEMA.map((key) => witness[key]));
+    expect(layout.bytes.length).toBe(WITHDRAWAL_PUBLIC_INPUT_SCHEMA.length * 32);
   });
 });

--- a/sdk/test/privacy_surface.test.ts
+++ b/sdk/test/privacy_surface.test.ts
@@ -1,0 +1,180 @@
+import fs from 'fs';
+import path from 'path';
+import { Note, NoteBackupError } from '../src/note';
+import {
+  MerkleProof,
+  PREPARED_WITHDRAWAL_WITNESS_SCHEMA,
+  PreparedWitness,
+  ProofGenerator,
+  ProvingBackend,
+} from '../src/proof';
+import { buildWithdrawalProofCacheKey, WithdrawalRequest } from '../src/withdraw';
+
+const G = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const RELAYER = 'GBZXN7PIRZGNMHGAH5Q4D5B4H3B7BWQ7M4CW67A4V6APSLW7M4Q6TLE5';
+const VECTORS_PATH = path.resolve(__dirname, 'golden/vectors.json');
+
+function makeNote(poolId: string = '11'.repeat(32), amount: bigint = 1000n): Note {
+  return new Note(
+    Buffer.from('01'.repeat(31), 'hex'),
+    Buffer.from('02'.repeat(31), 'hex'),
+    poolId,
+    amount
+  );
+}
+
+function makeMerkleProof(): MerkleProof {
+  return {
+    root: Buffer.from('03'.repeat(32), 'hex'),
+    pathElements: Array.from({ length: 20 }, () => Buffer.from('04'.repeat(32), 'hex')),
+    pathIndices: Array.from({ length: 20 }, () => 0),
+    leafIndex: 7,
+  };
+}
+
+function makeRequest(note: Note = makeNote()): WithdrawalRequest {
+  return {
+    note,
+    merkleProof: makeMerkleProof(),
+    recipient: G,
+    relayer: RELAYER,
+    fee: 5n,
+  };
+}
+
+describe('Privacy surface regression', () => {
+  it('exportBackup stays prefix + fixed-length hex without plaintext witness metadata', () => {
+    const backup = makeNote().exportBackup();
+
+    expect(backup).toMatch(/^privacylayer-note:[0-9a-f]+$/);
+    expect(backup.length).toBe('privacylayer-note:'.length + (107 * 2));
+    expect(backup).not.toContain('recipient');
+    expect(backup).not.toContain('nullifier_hash');
+    expect(backup).not.toContain('hash_path');
+    expect(backup).not.toContain('{');
+  });
+
+  it('importBackup rejects appended plaintext metadata after a valid payload', () => {
+    const backup = makeNote().exportBackup();
+
+    expect(() => Note.importBackup(`${backup}:debug-tag`)).toThrow(NoteBackupError);
+    try {
+      Note.importBackup(`${backup}:debug-tag`);
+    } catch (error) {
+      expect((error as NoteBackupError).code).toBe('CORRUPT_DATA');
+    }
+  });
+
+  it('legacy deserialize rejects appended plaintext metadata after a valid payload', () => {
+    const legacy = makeNote().serialize();
+
+    expect(() => Note.deserialize(`${legacy}:debug-tag`)).toThrow('Invalid note format');
+  });
+
+  it('prepareWitness emits only the circuit-facing witness schema', async () => {
+    const witness = await ProofGenerator.prepareWitness(
+      makeNote(),
+      makeMerkleProof(),
+      G,
+      RELAYER,
+      5n
+    );
+
+    expect(Object.keys(witness).sort()).toEqual([...PREPARED_WITHDRAWAL_WITNESS_SCHEMA].sort());
+    expect(witness).not.toHaveProperty('path_indices');
+    expect(witness).not.toHaveProperty('commitment');
+    expect(witness).not.toHaveProperty('backup');
+  });
+
+  it('ProofGenerator.generate strips extra metadata before sending the witness to the backend', async () => {
+    let backendWitness: PreparedWitness | undefined;
+    const backend: ProvingBackend = {
+      async generateProof(witness: PreparedWitness): Promise<Uint8Array> {
+        backendWitness = witness;
+        return new Uint8Array(256);
+      },
+    };
+
+    const prepared = await ProofGenerator.prepareWitness(
+      makeNote(),
+      makeMerkleProof(),
+      G,
+      RELAYER,
+      5n
+    );
+    const polluted = {
+      ...prepared,
+      recipient_strkey: G,
+      merkle_root_hex: prepared.root,
+      debug_label: 'do-not-send',
+      exported_note: makeNote().exportBackup(),
+    };
+
+    await new ProofGenerator(backend).generate(polluted);
+
+    expect(backendWitness).toBeDefined();
+    expect(Object.keys(backendWitness!).sort()).toEqual([...PREPARED_WITHDRAWAL_WITNESS_SCHEMA].sort());
+    expect(backendWitness).not.toHaveProperty('recipient_strkey');
+    expect(backendWitness).not.toHaveProperty('debug_label');
+    expect(backendWitness).not.toHaveProperty('exported_note');
+  });
+
+  it('proof cache key ignores duplicated request metadata outside the canonical witness', async () => {
+    const request = makeRequest();
+    const witness = await ProofGenerator.prepareWitness(
+      request.note,
+      request.merkleProof,
+      request.recipient,
+      request.relayer,
+      request.fee
+    );
+
+    const inconsistentRequest: WithdrawalRequest = {
+      note: makeNote('aa'.repeat(32), 777n),
+      merkleProof: makeMerkleProof(),
+      recipient: RELAYER,
+      relayer: G,
+      fee: 0n,
+    };
+
+    expect(buildWithdrawalProofCacheKey(request, witness)).toBe(
+      buildWithdrawalProofCacheKey(inconsistentRequest, witness)
+    );
+  });
+
+  it('golden vector fixture exports stay on the allowed field set only', () => {
+    const fixture = JSON.parse(fs.readFileSync(VECTORS_PATH, 'utf8'));
+
+    expect(Object.keys(fixture).sort()).toEqual(['description', 'hash_algorithm', 'vectors', 'version']);
+
+    for (const vector of fixture.vectors as any[]) {
+      expect(Object.keys(vector).sort()).toEqual([
+        'description',
+        'fields',
+        'id',
+        'merkle',
+        'note',
+        'nullifier_hash',
+        'public_inputs',
+      ]);
+      expect(Object.keys(vector.note).sort()).toEqual(['amount', 'nullifier_hex', 'pool_id', 'secret_hex']);
+      expect(Object.keys(vector.fields).sort()).toEqual(['nullifier', 'secret']);
+      expect(Object.keys(vector.merkle).sort()).toEqual(['leaf_index', 'path_elements', 'root']);
+      expect(Object.keys(vector.public_inputs).sort()).toEqual([
+        'amount',
+        'fee',
+        'nullifier_hash',
+        'recipient',
+        'relayer',
+        'root',
+      ]);
+
+      expect(vector).not.toHaveProperty('backup');
+      expect(vector).not.toHaveProperty('serialized_note');
+      expect(vector).not.toHaveProperty('witness');
+      expect(vector.note).not.toHaveProperty('backup');
+      expect(vector.note).not.toHaveProperty('recipient');
+      expect(vector.merkle).not.toHaveProperty('path_indices');
+    }
+  });
+});

--- a/sdk/test/proof_abstraction.test.ts
+++ b/sdk/test/proof_abstraction.test.ts
@@ -30,7 +30,6 @@ describe('Proving Path Abstraction', () => {
       note,
       merkleProof,
       recipient: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-      relayer: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
       fee: 0n
     };
     

--- a/sdk/test/proof_cache.test.ts
+++ b/sdk/test/proof_cache.test.ts
@@ -9,7 +9,7 @@ class CountingBackend implements ProvingBackend {
   async generateProof(witness: any): Promise<Uint8Array> {
     this.calls += 1;
     const digest = stableHash32('proof', JSON.stringify(witness));
-    const proof = new Uint8Array(64);
+    const proof = new Uint8Array(256);
     proof.set(digest, 0);
     proof.set(digest, 32);
     return proof;
@@ -34,8 +34,7 @@ function makeRequest(overrides: Partial<WithdrawalRequest> = {}): WithdrawalRequ
   return {
     note,
     merkleProof,
-    recipient: '0xrecipient',
-    relayer: '0xrelayer',
+    recipient: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
     fee: 0n,
     ...overrides
   };
@@ -68,8 +67,8 @@ describe('Withdrawal proof cache', () => {
     const backend = new CountingBackend();
     const cache = new InMemoryProofCache();
 
-    const firstRequest = makeRequest({ recipient: '0xalice' });
-    const secondRequest = makeRequest({ recipient: '0xbob' });
+    const firstRequest = makeRequest({ recipient: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF' });
+    const secondRequest = makeRequest({ recipient: 'GBZXN7PIRZGNMHGAH5Q4D5B4H3B7BWQ7M4CW67A4V6APSLW7M4Q6TLE5' });
 
     const witnessA = await ProofGenerator.prepareWitness(
       firstRequest.note,

--- a/sdk/test/verification_harness.test.ts
+++ b/sdk/test/verification_harness.test.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { Note } from '../src/note';
 import { MerkleProof, ProofGenerator, VerifyingBackend } from '../src/proof';
 import { verifyWithdrawalProof, extractPublicInputs } from '../src/withdraw';
+import { WithdrawalPublicInputs } from '../src/encoding';
+import { WitnessValidationError } from '../src/errors';
 
 class MockVerifyingBackend implements VerifyingBackend {
   constructor(private readonly expectedPublicInputs: string[]) {}
@@ -15,6 +17,31 @@ class MockVerifyingBackend implements VerifyingBackend {
     }
     return true;
   }
+}
+
+function makePublicInputs(overrides: Partial<WithdrawalPublicInputs> = {}): WithdrawalPublicInputs {
+  return {
+    pool_id: '11'.repeat(32),
+    root: '22'.repeat(32),
+    nullifier_hash: '33'.repeat(32),
+    recipient: '44'.repeat(32),
+    amount: '100',
+    relayer: '55'.repeat(32),
+    fee: '0',
+    ...overrides,
+  };
+}
+
+function asVerifierFieldList(publicInputs: WithdrawalPublicInputs): string[] {
+  return [
+    publicInputs.pool_id,
+    publicInputs.root,
+    publicInputs.nullifier_hash,
+    publicInputs.recipient,
+    publicInputs.amount,
+    publicInputs.relayer,
+    publicInputs.fee,
+  ];
 }
 
 describe('Verification Harness', () => {
@@ -32,15 +59,15 @@ describe('Verification Harness', () => {
 
   it('should verify a valid proof successfully', async () => {
     const proof = new Uint8Array(64).fill(0xab);
-    const publicInputs = ['pool', 'root', 'nullifier_hash', 'recipient', '100', 'relayer', '0'];
-    const backend = new MockVerifyingBackend(publicInputs);
+    const publicInputs = makePublicInputs();
+    const backend = new MockVerifyingBackend(asVerifierFieldList(publicInputs));
     const isValid = await verifyWithdrawalProof(proof, publicInputs, withdrawArtifact, backend);
     expect(isValid).toBe(true);
   });
 
   it('should fail verification for tampered proof bytes', async () => {
-    const publicInputs = ['pool', 'root', 'nullifier_hash', 'recipient', '100', 'relayer', '0'];
-    const backend = new MockVerifyingBackend(publicInputs);
+    const publicInputs = makePublicInputs();
+    const backend = new MockVerifyingBackend(asVerifierFieldList(publicInputs));
     const proof = new Uint8Array(64).fill(0xff);
     const isValid = await verifyWithdrawalProof(proof, publicInputs, withdrawArtifact, backend);
     expect(isValid).toBe(false);
@@ -56,12 +83,27 @@ describe('Verification Harness', () => {
     ['fee', 6],
   ])('should fail verification when %s is tampered', async (_label: string, idx: number) => {
     const proof = new Uint8Array(64).fill(0xab);
-    const good = ['pool', 'root', 'nullifier_hash', 'recipient', '100', 'relayer', '0'];
-    const backend = new MockVerifyingBackend(good);
-    const tampered = good.slice();
-    tampered[idx] = tampered[idx] + '_tampered';
+    const good = makePublicInputs();
+    const backend = new MockVerifyingBackend(asVerifierFieldList(good));
+    const tampered = { ...good };
+    const keys: (keyof WithdrawalPublicInputs)[] = ['pool_id', 'root', 'nullifier_hash', 'recipient', 'amount', 'relayer', 'fee'];
+    tampered[keys[idx]!] =
+      keys[idx] === 'amount' ? '101'
+      : keys[idx] === 'fee' ? '1'
+      : '66'.repeat(32);
     const isValid = await verifyWithdrawalProof(proof, tampered, withdrawArtifact, backend);
     expect(isValid).toBe(false);
+  });
+
+  it('rejects raw public-input arrays because schema order cannot be enforced', async () => {
+    await expect(
+      verifyWithdrawalProof(
+        new Uint8Array(64).fill(0xab),
+        ['pool', 'root', 'nullifier_hash', 'recipient', '100', 'relayer', '0'],
+        withdrawArtifact,
+        new MockVerifyingBackend([])
+      )
+    ).rejects.toThrow(WitnessValidationError);
   });
 
   it('should integrate generate and verify flow with extraction', async () => {

--- a/sdk/test/witness_mutation.test.ts
+++ b/sdk/test/witness_mutation.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { Note } from '../src/note';
-import { MerkleProof, PreparedWitness, ProofGenerator } from '../src/proof';
+import { MerkleProof, PreparedWitness, ProofGenerator, ProvingError } from '../src/proof';
 import { assertValidPreparedWithdrawalWitness, assertValidGroth16ProofBytes, GROTH16_PROOF_BYTE_LENGTH } from '../src/witness';
 import { WitnessValidationError } from '../src/errors';
 
@@ -111,6 +111,29 @@ describe('Fixture mutation contract (one dimension per case)', () => {
   });
 
   it('ProofGenerator.formatProof rejects under-long proof', () => {
-    expect(() => ProofGenerator.formatProof(new Uint8Array(1))).toThrow(WitnessValidationError);
+    expect(() =>
+      ProofGenerator.formatProof(new Uint8Array(1), {
+        pool_id: good.pool_id,
+        root: good.root,
+        nullifier_hash: good.nullifier_hash,
+        recipient: good.recipient,
+        amount: good.amount,
+        relayer: good.relayer,
+        fee: good.fee,
+      })
+    ).toThrow(ProvingError);
+  });
+
+  it('ProofGenerator.formatProof rejects missing public inputs before formatting completes', () => {
+    expect(() =>
+      ProofGenerator.formatProof(new Uint8Array(GROTH16_PROOF_BYTE_LENGTH), {
+        root: good.root,
+        nullifier_hash: good.nullifier_hash,
+        recipient: good.recipient,
+        amount: good.amount,
+        relayer: good.relayer,
+        fee: good.fee,
+      } as any)
+    ).toThrow('Invalid withdrawal public-input schema');
   });
 });

--- a/sdk/test/zk_integration.test.ts
+++ b/sdk/test/zk_integration.test.ts
@@ -19,7 +19,7 @@ class IntegrationProvingBackend implements ProvingBackend {
     }
 
     const digest = stableHash32('integration-proof', stableStringify(witness));
-    const proof = new Uint8Array(64);
+    const proof = new Uint8Array(256);
     proof.set(digest, 0);
     proof.set(digest, 32);
     proof[0] = 0xab;
@@ -29,7 +29,7 @@ class IntegrationProvingBackend implements ProvingBackend {
 
 class IntegrationVerifyingBackend implements VerifyingBackend {
   async verifyProof(proof: Uint8Array, publicInputs: string[]): Promise<boolean> {
-    if (proof.length !== 64 || proof[0] !== 0xab) {
+    if (proof.length !== 256 || proof[0] !== 0xab) {
       return false;
     }
 
@@ -45,16 +45,16 @@ const FIXTURES = {
     seed: 'zk-valid-fixture',
     poolId: '44'.repeat(32),
     amount: 1000n,
-    recipient: '0xrecipient-valid',
-    relayer: '0xrelayer-valid',
+    recipient: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    relayer: 'GBZXN7PIRZGNMHGAH5Q4D5B4H3B7BWQ7M4CW67A4V6APSLW7M4Q6TLE5',
     fee: 5n
   },
   invalid: {
     seed: 'zk-invalid-fixture',
     poolId: '55'.repeat(32),
     amount: 500n,
-    recipient: '0xrecipient-invalid',
-    relayer: '0xrelayer-invalid',
+    recipient: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    relayer: 'GBZXN7PIRZGNMHGAH5Q4D5B4H3B7BWQ7M4CW67A4V6APSLW7M4Q6TLE5',
     fee: 501n
   }
 };
@@ -92,13 +92,13 @@ describe('SDK ZK integration flow', () => {
     const publicInputs = extractPublicInputs(witness);
     const isValid = await verifyWithdrawalProof(
       proof,
-      publicInputs,
+      witness,
       { fixture: 'withdraw-artifact' },
       new IntegrationVerifyingBackend()
     );
 
     expect(isValid).toBe(true);
-    expect(proof.length).toBe(64);
+    expect(proof.length).toBe(256);
     expect(stableHash32('pi', stableStringify(publicInputs)).length).toBe(32);
   });
 


### PR DESCRIPTION
## Wave Ticket

Wave Issue Keys: `ZK-045`, `ZK-067`

Linked issues:
- Closes #289
- Closes #311

## What Changed

**Verifier Boundary & Encoding (ZK-045)**
- Introduced `serializeWithdrawalPublicInputs` in `sdk/src/encoding.ts` to act as the single source of truth for public-input field arrays and 32-byte verifier layouts.
- Routed both proof payload construction (`formatProof`) and off-chain verification tests through this new shared code path, removing ad-hoc array definitions.
- Refactored functions to accept strict `WithdrawalPublicInputs` objects, failing fast with `ProvingError` / `WitnessValidationError` on missing or unordered fields.

**Privacy Regression & Payload Metadata (ZK-067)**
- Hardened `Note` backup string ingestion (`sdk/src/note.ts`) with strict regex and payload length bounds to reject appended plaintext leaks (e.g., `:debug-tag`).
- Added `canonicalizePreparedWitness` in `sdk/src/proof.ts` to explicitly strip non-circuit-facing metadata before passing payloads to the backend prover.
- Minimized `buildWithdrawalProofCacheKey` to derive its identity purely from canonical witness fields rather than duplicated request variables.
- Added `sdk/test/privacy_surface.test.ts` to strictly pin allowed fixture fields, backup payloads, and witness structures.
- Expanded `sdk/test/golden_vectors.test.ts` to assert exact byte/field orders and updated `circuits/TEST_VECTORS.md` to reflect the canonical public-input layout.

## Validation

- [x] I linked the ZK ticket key above.
- [x] I ran `node scripts/zk_ticket_check.mjs --issue-key ZK-045` and `ZK-067`.
- [x] I ran the derived checks locally for the ticket I am implementing.
-[x] I updated tests or fixtures when the ticket changed circuit or witness behavior.

Validation output:

```text
ZK-045: Encode withdrawal public inputs for the verifier boundary using the canonical packing schema
Area: prover
Priority: High
Complexity: Medium

Relevant code:
- sdk/src/proof.ts
- contracts/privacy_pool/src/crypto/verifier.rs

Validation checks:
- (circuits) nargo check --workspace
- (circuits) nargo test --workspace
- (sdk) npm run build

ZK-067: Add privacy-regression coverage for note strings, fixtures, and witness payload metadata
Area: security
Priority: Medium
Complexity: Medium

Relevant code:
- sdk/src/note.ts
- sdk/src/proof.ts
- circuits/TEST_VECTORS.md

Validation checks:
- (circuits) nargo check --workspace
- (circuits) nargo test --workspace
- (sdk) npm run build