### PR TITLE
feat(sdk,merkle): sync format spec, bootstrap-root fixtures, full-level tamper matrix, pool_id divergence tests

### DIFF
--- a/sdk/docs/MERKLE_SYNC_FORMAT.md
+++ b/sdk/docs/MERKLE_SYNC_FORMAT.md
@@ -1,0 +1,100 @@
+# Client-side Merkle synchronization format (ZK-023)
+
+The SDK rebuilds the deposit tree from indexed events so it can produce
+withdrawal proofs offline. To avoid recomputing from the genesis root on
+every run, the SDK persists a `MerkleCheckpoint` and resumes from it on
+the next session.
+
+This doc is the contract for that format. Anything that produces or
+consumes a checkpoint — the SDK, fixture tooling, and proof-generation
+code paths — MUST agree with what is described here. The format is
+deliberately storage-agnostic: persist the JSON-serializable object on
+whatever the host environment provides (browser `localStorage`, a
+Node-side file, IndexedDB, encrypted disk).
+
+## Format
+
+```ts
+interface MerkleCheckpoint {
+  /** Schema version. Bumped on any breaking change. */
+  version: 1;
+
+  /** Tree depth captured by this checkpoint. Must equal `MERKLE_TREE_DEPTH`. */
+  depth: number;
+
+  /** Number of leaves committed so far. Equal to the index where the next leaf will land. */
+  nextIndex: number;
+
+  /** Hex-encoded current Merkle root (32 bytes, lowercase, no `0x`). */
+  root: string;
+
+  /**
+   * Frontier — the rightmost path of the tree. One slot per level (`depth`
+   * entries). `null` indicates the slot is the canonical zero node for that
+   * level. The frontier alone is enough to keep ingesting new leaves; it is
+   * NOT enough to prove inclusion of historical leaves.
+   */
+  frontier: Array<string | null>;
+
+  /**
+   * Optional: every leaf observed so far, in insertion order. Required to
+   * generate proofs for arbitrary historical leaves; omitted if the
+   * checkpoint is consumed only to keep ingesting new leaves.
+   */
+  leaves?: string[];
+}
+```
+
+## Determinism guarantees
+
+The format is restart-safe because every `LocalMerkleTree` operation is
+pure: insertion order, `frontier`, and `root` are determined by the leaf
+sequence alone. Specifically:
+
+1. **Same input, same output.** A tree built by inserting `[c0, c1, …]`
+   one-at-a-time produces the same root as a tree built by
+   `insertBatch([c0, c1, …])`.
+2. **Round-trip preservation.** `LocalMerkleTree.fromCheckpoint(t.createCheckpoint())`
+   yields a tree whose `getRoot()`, `leafCount`, and subsequent
+   insertion behavior match `t` exactly.
+3. **Resumability.** Inserting leaves `N` through `M` into a checkpoint
+   produced after leaf `N-1` yields the same tree as inserting leaves
+   `0` through `M` from scratch.
+
+These guarantees are pinned by `test/merkle_checkpoint.test.ts` and the
+new `test/merkle_sync_format.test.ts` round-trip suite (ZK-023).
+
+## Usage from proof generation
+
+Proof generation calls `LocalMerkleTree.generateProof(leafIndex)`, which
+requires the in-memory leaves array. Persist with `includeLeaves: true`
+when the SDK needs to prove arbitrary historical leaves; omit `leaves`
+to keep the checkpoint cheap (it stays small and only supports continued
+ingestion).
+
+```ts
+const tree = new LocalMerkleTree();
+tree.insertBatch(commitmentsFromIndexer);
+
+// Persist
+await storage.put("merkle-checkpoint", tree.createCheckpoint({ includeLeaves: true }));
+
+// Resume
+const restored = LocalMerkleTree.fromCheckpoint(await storage.get("merkle-checkpoint"));
+restored.insertBatch(newerCommitments);
+const proof = restored.generateProof(targetLeafIndex);
+```
+
+## Versioning
+
+`version: 1` is the only currently-supported value. Any breaking change
+(e.g. switching the leaf hash domain, packing the frontier differently,
+adding a required field) MUST bump `version` and add an entry to the
+changelog below; older checkpoints become unreadable and the SDK rebuilds
+from genesis.
+
+## Changelog
+
+| Version | Date (UTC) | Change |
+|---|---|---|
+| 1 | 2026-04-26 | Initial format (ZK-023). |

--- a/sdk/src/merkle.ts
+++ b/sdk/src/merkle.ts
@@ -65,6 +65,71 @@ export interface MerkleFixtureGenerationOptions {
   proveLeafIndices?: number[];
 }
 
+/**
+ * Empty-tree / bootstrap-root fixture for a single (pool, denomination) class
+ * (ZK-025). Generated deterministically from `LocalMerkleTree`'s zero-node
+ * ladder so the SDK and the on-chain pool agree on the initial root the very
+ * first deposit will be verified against.
+ */
+export interface EmptyTreeFixture {
+  poolId: string;
+  denomination: string;
+  depth: number;
+  /** Hex-encoded canonical empty root for this (pool, denomination). */
+  rootHex: string;
+  /** Per-level zero nodes: `zeroLadder[i]` is the hash of two `zeroLadder[i-1]`. */
+  zeroLadderHex: string[];
+}
+
+/**
+ * Compute the canonical zero-node ladder for the given depth.
+ *
+ * Exposed so fixture tooling can derive empty roots without instantiating a
+ * `LocalMerkleTree`. The zero ladder is the SHA-2-driven recursive hash of
+ * `Buffer.alloc(32, 0)`; matches the per-instance ladder used internally.
+ */
+export function computeMerkleZeroLadder(
+  depth: number = PRODUCTION_MERKLE_TREE_DEPTH,
+): Buffer[] {
+  assertMerkleDepth(depth);
+  // We use a throwaway tree solely to access its private buildZeroes via the
+  // documented constructor path; the resulting ladder is identical regardless
+  // of which tree instance produced it.
+  const tree = new LocalMerkleTree(depth);
+  const ladder: Buffer[] = [];
+  // The first slot is always the all-zero leaf; subsequent slots derive from
+  // it via the same `hashPair` used during normal insertion. We round-trip
+  // through `getRoot()` of an empty tree to capture the canonical root.
+  for (let level = 0; level <= depth; level += 1) {
+    ladder.push(Buffer.from((tree as any).zeroes[level]));
+  }
+  return ladder;
+}
+
+/**
+ * Generate one bootstrap-root fixture per supplied (poolId, denomination)
+ * combination (ZK-025). Roots are deterministic and protocol-derived — there
+ * are no hand-entered values.
+ */
+export function generateBootstrapRootFixtures(
+  classes: Array<{ poolId: string; denomination: string }>,
+  depth: number = PRODUCTION_MERKLE_TREE_DEPTH,
+): EmptyTreeFixture[] {
+  if (classes.length === 0) {
+    throw new Error("generateBootstrapRootFixtures requires at least one class");
+  }
+  const ladder = computeMerkleZeroLadder(depth);
+  const rootHex = ladder[depth]!.toString("hex");
+  const zeroLadderHex = ladder.map((entry) => entry.toString("hex"));
+  return classes.map(({ poolId, denomination }) => ({
+    poolId,
+    denomination,
+    depth,
+    rootHex,
+    zeroLadderHex,
+  }));
+}
+
 function toLeaf(commitment: CommitmentLike): Buffer {
   if (Buffer.isBuffer(commitment) || commitment instanceof Uint8Array) {
     const bytes = Buffer.from(commitment);

--- a/sdk/src/proof.ts
+++ b/sdk/src/proof.ts
@@ -190,6 +190,8 @@ function canonicalizePreparedWitness(witness: PreparedWitness): PreparedWitness 
     relayer: witness.relayer,
     fee: witness.fee,
   };
+}
+
 export interface WitnessPreparationOptions {
   merkleDepth?: number;
 }

--- a/sdk/src/withdraw.ts
+++ b/sdk/src/withdraw.ts
@@ -1,13 +1,3 @@
-import { Note } from './note';
-import { MerkleProof, PreparedWitness, ProofCache, ProofGenerator, ProvingBackend, VerifyingBackend } from './proof';
-import { BatchSyncResult, CommitmentLike, LocalMerkleTree, MerkleCheckpoint, syncCommitmentBatch } from './merkle';
-import {
-  SerializedWithdrawalPublicInputs,
-  WithdrawalPublicInputs,
-  serializeWithdrawalPublicInputs,
-} from './encoding';
-import { stableHash32, stableStringify } from './stable';
-import { WitnessValidationError } from './errors';
 import { Note } from "./note";
 import {
   MerkleProof,
@@ -24,7 +14,13 @@ import {
   MerkleCheckpoint,
   syncCommitmentBatch,
 } from "./merkle";
+import {
+  SerializedWithdrawalPublicInputs,
+  WithdrawalPublicInputs,
+  serializeWithdrawalPublicInputs,
+} from "./encoding";
 import { stableHash32, stableStringify } from "./stable";
+import { WitnessValidationError } from "./errors";
 
 /**
  * WithdrawalRequest
@@ -53,15 +49,15 @@ interface WithdrawalCacheMaterial {
     hash_path: string[];
   };
   publicInputs: WithdrawalPublicInputs;
+  pool: string;
+  denomination: string;
 }
-
-function buildCacheMaterial(witness: PreparedWitness): WithdrawalCacheMaterial {
-  const serialized = serializeWithdrawalPublicInputs(witness);
 
 function buildCacheMaterial(
   request: WithdrawalRequest,
   witness: PreparedWitness,
 ): WithdrawalCacheMaterial {
+  const serialized = serializeWithdrawalPublicInputs(witness);
   return {
     privateInputs: {
       nullifier: witness.nullifier,
@@ -69,30 +65,17 @@ function buildCacheMaterial(
       leaf_index: witness.leaf_index,
       hash_path: witness.hash_path.slice(),
     },
-    publicInputs: serialized.values
-      pool: request.note.poolId,
-      denomination: witness.amount,
-    },
-    root: witness.root,
+    publicInputs: serialized.values,
     pool: request.note.poolId,
-    publicInputs: {
-      root: witness.root,
-      nullifier_hash: witness.nullifier_hash,
-      recipient: witness.recipient,
-      amount: witness.amount,
-      relayer: witness.relayer,
-      fee: witness.fee,
-    },
+    denomination: witness.amount,
   };
 }
 
 export function buildWithdrawalProofCacheKey(
-  _request: WithdrawalRequest,
-  witness: PreparedWitness
   request: WithdrawalRequest,
   witness: PreparedWitness,
 ): string {
-  const material = buildCacheMaterial(witness);
+  const material = buildCacheMaterial(request, witness);
   const canonical = stableStringify(material);
   return `withdraw-proof:${stableHash32("withdraw-proof-cache-v1", canonical).toString("hex")}`;
 }
@@ -115,19 +98,19 @@ export function restoreWithdrawalTree(
 }
 
 function assertNamedWithdrawalPublicInputs(
-  publicInputs: WithdrawalPublicInputs | PreparedWitness | string[]
+  publicInputs: WithdrawalPublicInputs | PreparedWitness | string[],
 ): asserts publicInputs is WithdrawalPublicInputs | PreparedWitness {
   if (Array.isArray(publicInputs)) {
     throw new WitnessValidationError(
-      'Public inputs must be provided as named fields so canonical schema order can be enforced',
-      'PUBLIC_INPUT_SCHEMA',
-      'structure'
+      "Public inputs must be provided as named fields so canonical schema order can be enforced",
+      "PUBLIC_INPUT_SCHEMA",
+      "structure",
     );
   }
 }
 
 export function buildWithdrawalPublicInputLayout(
-  publicInputs: WithdrawalPublicInputs | PreparedWitness
+  publicInputs: WithdrawalPublicInputs | PreparedWitness,
 ): SerializedWithdrawalPublicInputs {
   return serializeWithdrawalPublicInputs(publicInputs);
 }
@@ -175,7 +158,10 @@ export async function generateWithdrawalProof(
   });
 
   // 3. Format the proof for the Soroban contract
-  const proof = ProofGenerator.formatProof(rawProof, buildWithdrawalPublicInputLayout(witness).values);
+  const proof = ProofGenerator.formatProof(
+    rawProof,
+    buildWithdrawalPublicInputLayout(witness).values,
+  );
   if (options.cache) {
     await options.cache.set(key, proof);
   }
@@ -185,20 +171,11 @@ export async function generateWithdrawalProof(
 /**
  * extractPublicInputs
  *
- * Extracts the 7 public inputs from a prepared witness in the canonical order
+ * Extracts the public inputs from a prepared witness in the canonical order
  * defined by WITHDRAWAL_PUBLIC_INPUT_SCHEMA (pool_id … fee).
  */
 export function extractPublicInputs(witness: PreparedWitness): string[] {
   return buildWithdrawalPublicInputLayout(witness).fields;
-  return [
-    witness.pool_id, // 0
-    witness.root, // 1
-    witness.nullifier_hash, // 2
-    witness.recipient, // 3
-    witness.amount, // 4
-    witness.relayer, // 5
-    witness.fee, // 6
-  ];
 }
 
 /**
@@ -218,5 +195,9 @@ export async function verifyWithdrawalProof(
   backend: VerifyingBackend,
 ): Promise<boolean> {
   assertNamedWithdrawalPublicInputs(publicInputs);
-  return backend.verifyProof(proof, buildWithdrawalPublicInputLayout(publicInputs).fields, artifacts);
+  return backend.verifyProof(
+    proof,
+    buildWithdrawalPublicInputLayout(publicInputs).fields,
+    artifacts,
+  );
 }

--- a/sdk/src/witness.ts
+++ b/sdk/src/witness.ts
@@ -106,14 +106,6 @@ export function assertValidStellarAccountId(
  * Verifies a prepared witness object for structural safety and protocol consistency
  * (nullifier hash binding, fee / relayer rules) before a proving backend is invoked.
  */
-export function assertValidPreparedWithdrawalWitness(witness: PreparedWitness): void {
-  assertFieldHexString(witness.pool_id, 'pool_id');
-  assertFieldHexString(witness.nullifier, 'nullifier');
-  assertFieldHexString(witness.secret, 'secret');
-  assertFieldHexString(witness.root, 'root');
-  assertFieldHexString(witness.nullifier_hash, 'nullifier_hash');
-  assertFieldHexString(witness.recipient, 'recipient');
-  assertFieldHexString(witness.relayer, 'relayer');
 export function assertValidPreparedWithdrawalWitness(
   witness: PreparedWitness,
   options: WitnessValidationOptions = {},
@@ -124,6 +116,7 @@ export function assertValidPreparedWithdrawalWitness(
   );
   const maxLeafIndex = merkleMaxLeafIndex(expectedDepth);
 
+  assertFieldHexString(witness.pool_id, "pool_id");
   assertFieldHexString(witness.nullifier, "nullifier");
   assertFieldHexString(witness.secret, "secret");
   assertFieldHexString(witness.root, "root");

--- a/sdk/src/zk_constants.ts
+++ b/sdk/src/zk_constants.ts
@@ -8,6 +8,13 @@ export const GROTH16_PROOF_BYTE_LENGTH = 256;
 
 export const ZERO_FIELD_HEX = '0'.repeat(64);
 
+/**
+ * Canonical Stellar zero-account strkey used as the default relayer when no
+ * relayer is configured. The matching field representation is `ZERO_FIELD_HEX`.
+ */
+export const STELLAR_ZERO_ACCOUNT =
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
 // BN254 scalar field prime
 // r = 21888242871839275222246405745257275088548364400416034343698204186575808495617
 export const FIELD_MODULUS =

--- a/sdk/test/empty_tree_fixtures.test.ts
+++ b/sdk/test/empty_tree_fixtures.test.ts
@@ -1,0 +1,89 @@
+/// <reference types="jest" />
+import {
+  LocalMerkleTree,
+  computeMerkleZeroLadder,
+  generateBootstrapRootFixtures,
+  PRODUCTION_MERKLE_TREE_DEPTH,
+} from "../src/merkle";
+
+/**
+ * ZK-025: empty-tree and bootstrap-root fixtures.
+ *
+ * These tests pin the relationship between the canonical zero-node ladder,
+ * the empty-tree root, and a freshly-instantiated `LocalMerkleTree`. If any
+ * of them break, fixture generation has drifted from runtime behaviour and
+ * the first deposit into a pool will be rejected on-chain.
+ */
+
+describe("Empty-tree / bootstrap-root fixtures (ZK-025)", () => {
+  it("zero-ladder length is depth+1 (one entry per level + leaf level 0)", () => {
+    const ladder = computeMerkleZeroLadder(8);
+    expect(ladder).toHaveLength(9);
+    for (const entry of ladder) {
+      expect(entry).toBeInstanceOf(Buffer);
+      expect(entry.length).toBe(32);
+    }
+  });
+
+  it("ladder[0] is the all-zero 32-byte leaf", () => {
+    const ladder = computeMerkleZeroLadder(8);
+    expect(ladder[0]!.equals(Buffer.alloc(32, 0))).toBe(true);
+  });
+
+  it("the empty-tree root matches a freshly-constructed LocalMerkleTree's root", () => {
+    for (const depth of [4, 8, 16, PRODUCTION_MERKLE_TREE_DEPTH]) {
+      const ladder = computeMerkleZeroLadder(depth);
+      const tree = new LocalMerkleTree(depth);
+      expect(ladder[depth]!.equals(tree.getRoot())).toBe(true);
+    }
+  });
+
+  it("zero-ladder is deterministic across calls", () => {
+    const a = computeMerkleZeroLadder(12);
+    const b = computeMerkleZeroLadder(12);
+    for (let i = 0; i < a.length; i += 1) {
+      expect(a[i]!.equals(b[i]!)).toBe(true);
+    }
+  });
+
+  it("generates one fixture per (pool, denomination) class with the same canonical root", () => {
+    const classes = [
+      { poolId: "pool-A", denomination: "1xlm" },
+      { poolId: "pool-A", denomination: "10xlm" },
+      { poolId: "pool-B", denomination: "1xlm" },
+    ];
+    const fixtures = generateBootstrapRootFixtures(classes, 8);
+    expect(fixtures).toHaveLength(3);
+
+    const expectedRoot = computeMerkleZeroLadder(8)[8]!.toString("hex");
+    for (const fixture of fixtures) {
+      expect(fixture.depth).toBe(8);
+      expect(fixture.rootHex).toBe(expectedRoot);
+      expect(fixture.zeroLadderHex).toHaveLength(9);
+    }
+
+    expect(fixtures[0]).toMatchObject({ poolId: "pool-A", denomination: "1xlm" });
+    expect(fixtures[1]).toMatchObject({ poolId: "pool-A", denomination: "10xlm" });
+    expect(fixtures[2]).toMatchObject({ poolId: "pool-B", denomination: "1xlm" });
+  });
+
+  it("the SDK initializes a tree from the empty-root fixture", () => {
+    const [fixture] = generateBootstrapRootFixtures(
+      [{ poolId: "pool-A", denomination: "1xlm" }],
+      6,
+    );
+    const tree = new LocalMerkleTree(fixture!.depth);
+    expect(tree.getRoot().toString("hex")).toBe(fixture!.rootHex);
+  });
+
+  it("rejects empty class lists", () => {
+    expect(() => generateBootstrapRootFixtures([])).toThrow();
+  });
+
+  it("production depth fixture lines up with PRODUCTION_MERKLE_TREE_DEPTH", () => {
+    const [fixture] = generateBootstrapRootFixtures([
+      { poolId: "p", denomination: "d" },
+    ]);
+    expect(fixture!.depth).toBe(PRODUCTION_MERKLE_TREE_DEPTH);
+  });
+});

--- a/sdk/test/golden_vectors.test.ts
+++ b/sdk/test/golden_vectors.test.ts
@@ -11,9 +11,8 @@ import {
   serializeWithdrawalPublicInputs,
   stellarAddressToField,
   WITHDRAWAL_PUBLIC_INPUT_SCHEMA,
-} from '../src/encoding';
-import { buildWithdrawalPublicInputLayout } from '../src/withdraw';
 } from "../src/encoding";
+import { buildWithdrawalPublicInputLayout } from "../src/withdraw";
 
 // ---------------------------------------------------------------------------
 // Load golden fixture
@@ -367,7 +366,6 @@ describe("Withdrawal public-input schema ordering (ZK-032)", () => {
     ].join(''));
   });
 
-  it('prepareWitness public fields align with WITHDRAWAL_PUBLIC_INPUT_SCHEMA', async () => {
   it("prepareWitness public fields align with WITHDRAWAL_PUBLIC_INPUT_SCHEMA", async () => {
     const v = fixture.vectors[0];
     const note = buildNote(v);

--- a/sdk/test/merkle_sync_format.test.ts
+++ b/sdk/test/merkle_sync_format.test.ts
@@ -1,0 +1,160 @@
+/// <reference types="jest" />
+import {
+  LocalMerkleTree,
+  syncCommitmentBatch,
+  type MerkleCheckpoint,
+} from "../src/merkle";
+import { stableHash32 } from "../src/stable";
+
+/**
+ * Pins the guarantees documented in `sdk/docs/MERKLE_SYNC_FORMAT.md` (ZK-023).
+ * If any of these tests start failing, either the SDK semantics changed or the
+ * sync format spec did — bump the format version and update both together.
+ */
+
+const DEPTH = 6; // small depth for fast deterministic fixtures
+const LEAF_COUNT = 1 << (DEPTH - 1); // half-fill the tree (32 leaves)
+
+function leaf(i: number): Buffer {
+  return stableHash32("zk-023-leaf", i);
+}
+
+function makeLeaves(count: number): Buffer[] {
+  return Array.from({ length: count }, (_, i) => leaf(i));
+}
+
+describe("Merkle sync format (ZK-023)", () => {
+  it("checkpoint shape matches the documented schema", () => {
+    const tree = new LocalMerkleTree(DEPTH);
+    tree.insertBatch(makeLeaves(LEAF_COUNT));
+
+    const checkpoint = tree.createCheckpoint();
+
+    expect(checkpoint.version).toBe(1);
+    expect(checkpoint.depth).toBe(DEPTH);
+    expect(checkpoint.nextIndex).toBe(LEAF_COUNT);
+    expect(typeof checkpoint.root).toBe("string");
+    expect(checkpoint.root).toMatch(/^[0-9a-f]{64}$/);
+    expect(checkpoint.frontier).toHaveLength(DEPTH);
+    for (const entry of checkpoint.frontier) {
+      if (entry !== null) {
+        expect(entry).toMatch(/^[0-9a-f]{64}$/);
+      }
+    }
+    expect(checkpoint.leaves).toBeUndefined();
+  });
+
+  it("includeLeaves option round-trips every leaf", () => {
+    const leaves = makeLeaves(LEAF_COUNT);
+    const tree = new LocalMerkleTree(DEPTH);
+    tree.insertBatch(leaves);
+
+    const checkpoint = tree.createCheckpoint({ includeLeaves: true });
+    expect(checkpoint.leaves).toHaveLength(LEAF_COUNT);
+    for (let i = 0; i < LEAF_COUNT; i += 1) {
+      expect(checkpoint.leaves![i]).toBe(leaves[i]!.toString("hex"));
+    }
+  });
+
+  it("checkpoint is JSON round-trip safe", () => {
+    const tree = new LocalMerkleTree(DEPTH);
+    tree.insertBatch(makeLeaves(LEAF_COUNT));
+    const original = tree.createCheckpoint({ includeLeaves: true });
+    const round: MerkleCheckpoint = JSON.parse(JSON.stringify(original));
+    expect(round).toEqual(original);
+
+    const restored = LocalMerkleTree.fromCheckpoint(round);
+    expect(restored.getRoot().toString("hex")).toBe(original.root);
+    expect(restored.leafCount).toBe(original.nextIndex);
+  });
+
+  it("guarantee 1 — sequential and batch insertion produce the same root", () => {
+    const leaves = makeLeaves(LEAF_COUNT);
+
+    const sequential = new LocalMerkleTree(DEPTH);
+    for (const value of leaves) sequential.insert(value);
+
+    const batched = new LocalMerkleTree(DEPTH);
+    batched.insertBatch(leaves);
+
+    expect(batched.getRoot().equals(sequential.getRoot())).toBe(true);
+  });
+
+  it("guarantee 2 — restoring a checkpoint preserves root, leafCount, and continued behavior", () => {
+    const leaves = makeLeaves(LEAF_COUNT);
+    const tree = new LocalMerkleTree(DEPTH);
+    tree.insertBatch(leaves);
+
+    const restored = LocalMerkleTree.fromCheckpoint(
+      tree.createCheckpoint({ includeLeaves: true }),
+    );
+    expect(restored.getRoot().equals(tree.getRoot())).toBe(true);
+    expect(restored.leafCount).toBe(tree.leafCount);
+
+    // Inserting one more leaf must produce the same root as inserting the same
+    // leaf into the original tree.
+    const extra = leaf(LEAF_COUNT);
+    tree.insert(extra);
+    restored.insert(extra);
+    expect(restored.getRoot().equals(tree.getRoot())).toBe(true);
+  });
+
+  it("guarantee 3 — resuming from a mid-history checkpoint matches a from-scratch rebuild", () => {
+    const all = makeLeaves(LEAF_COUNT);
+    const split = LEAF_COUNT / 2;
+
+    // Resumed path: build half, checkpoint, resume, then add the rest.
+    const partial = new LocalMerkleTree(DEPTH);
+    partial.insertBatch(all.slice(0, split));
+    const resumed = LocalMerkleTree.fromCheckpoint(
+      partial.createCheckpoint({ includeLeaves: true }),
+    );
+    resumed.insertBatch(all.slice(split));
+
+    // Rebuilt path: build everything in one shot.
+    const rebuilt = new LocalMerkleTree(DEPTH);
+    rebuilt.insertBatch(all);
+
+    expect(resumed.getRoot().equals(rebuilt.getRoot())).toBe(true);
+    expect(resumed.leafCount).toBe(rebuilt.leafCount);
+  });
+
+  it("syncCommitmentBatch returns a checkpoint compatible with fromCheckpoint", () => {
+    const tree = new LocalMerkleTree(DEPTH);
+    const result = syncCommitmentBatch(tree, makeLeaves(8), {
+      includeLeaves: true,
+    });
+    expect(result.checkpoint.version).toBe(1);
+    expect(result.insertedLeafIndices).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+
+    const restored = LocalMerkleTree.fromCheckpoint(result.checkpoint);
+    expect(restored.getRoot().equals(result.root)).toBe(true);
+  });
+
+  it("checkpoint without leaves still supports continued ingestion (small footprint mode)", () => {
+    const tree = new LocalMerkleTree(DEPTH);
+    tree.insertBatch(makeLeaves(LEAF_COUNT));
+    const lean = tree.createCheckpoint(); // leaves omitted
+    expect(lean.leaves).toBeUndefined();
+
+    const restored = LocalMerkleTree.fromCheckpoint(lean);
+    expect(restored.getRoot().equals(tree.getRoot())).toBe(true);
+
+    const extra = leaf(LEAF_COUNT);
+    tree.insert(extra);
+    restored.insert(extra);
+    expect(restored.getRoot().equals(tree.getRoot())).toBe(true);
+  });
+
+  it("rejects checkpoints whose frontier length does not match depth", () => {
+    const tree = new LocalMerkleTree(DEPTH);
+    tree.insertBatch(makeLeaves(4));
+    const checkpoint = tree.createCheckpoint();
+    const corrupted: MerkleCheckpoint = {
+      ...checkpoint,
+      frontier: checkpoint.frontier.slice(0, DEPTH - 1),
+    };
+
+    expect(() => LocalMerkleTree.fromCheckpoint(corrupted)).toThrow();
+  });
+});

--- a/sdk/test/merkle_tamper_matrix.test.ts
+++ b/sdk/test/merkle_tamper_matrix.test.ts
@@ -1,0 +1,138 @@
+/// <reference types="jest" />
+import { LocalMerkleTree } from "../src/merkle";
+import { stableHash32 } from "../src/stable";
+import type { MerkleProof } from "../src/proof";
+
+/**
+ * ZK-027: Merkle sibling-tamper regression matrix.
+ *
+ * For every level of the tree, mutate exactly one sibling and confirm that
+ * the resulting proof either fails recomputation against the published root
+ * or fails structural validation. Covers both left-leaf and right-leaf
+ * positions so an off-by-one sibling lookup can't slip through.
+ */
+
+const DEPTH = 20; // production depth
+
+function leaf(i: number): Buffer {
+  return stableHash32("zk-027-leaf", i);
+}
+
+function flipFirstByte(buf: Buffer): Buffer {
+  const out = Buffer.from(buf);
+  out[0] = out[0]! ^ 0x01;
+  return out;
+}
+
+/**
+ * Re-derive the root from a (possibly tampered) `MerkleProof`. Mirrors the
+ * Merkle hashing the circuit performs, so a bad sibling at any level shows
+ * up as a root mismatch.
+ */
+function recomputeRoot(proof: MerkleProof, leafBytes: Buffer): Buffer {
+  if (proof.pathIndices === undefined) {
+    throw new Error("pathIndices required for recompute");
+  }
+  let current = leafBytes;
+  for (let level = 0; level < proof.pathElements.length; level += 1) {
+    const sibling = proof.pathElements[level]!;
+    const isRight = (proof.pathIndices[level]! & 1) === 1;
+    current = isRight
+      ? stableHash32("merkle-node", sibling, current)
+      : stableHash32("merkle-node", current, sibling);
+  }
+  return current;
+}
+
+/** Build a populated tree and return a (good) proof for `targetIndex`. */
+function buildScenario(targetIndex: number): {
+  tree: LocalMerkleTree;
+  leafBytes: Buffer;
+  goodProof: MerkleProof;
+} {
+  const tree = new LocalMerkleTree(DEPTH);
+  // Insert enough leaves so every level has at least one non-zero sibling
+  // somewhere along the path; 64 is comfortably above 2^DEPTH=20 path length.
+  const leafCount = Math.max(targetIndex + 1, 64);
+  for (let i = 0; i < leafCount; i += 1) {
+    tree.insert(leaf(i));
+  }
+  return {
+    tree,
+    leafBytes: leaf(targetIndex),
+    goodProof: tree.generateProof(targetIndex),
+  };
+}
+
+describe("Merkle sibling tamper matrix (ZK-027)", () => {
+  it("baseline — the unmodified proof recomputes to the published root", () => {
+    const { tree, leafBytes, goodProof } = buildScenario(0);
+    expect(recomputeRoot(goodProof, leafBytes).equals(tree.getRoot())).toBe(true);
+  });
+
+  describe.each([
+    { name: "left leaf position", targetIndex: 4 },
+    { name: "right leaf position", targetIndex: 5 },
+  ])("$name", ({ targetIndex }) => {
+    const { tree, leafBytes, goodProof } = buildScenario(targetIndex);
+    const expectedRoot = tree.getRoot();
+
+    it.each(Array.from({ length: DEPTH }, (_, level) => level))(
+      "tampering with the sibling at level %i breaks the recomputed root",
+      (level) => {
+        const tamperedProof: MerkleProof = {
+          ...goodProof,
+          pathElements: goodProof.pathElements.map((sibling, i) =>
+            i === level ? flipFirstByte(sibling) : Buffer.from(sibling),
+          ),
+        };
+
+        const recomputed = recomputeRoot(tamperedProof, leafBytes);
+        expect(recomputed.equals(expectedRoot)).toBe(false);
+      },
+    );
+
+    it.each(Array.from({ length: DEPTH }, (_, level) => level))(
+      "swapping the index bit at level %i breaks the recomputed root",
+      (level) => {
+        const tamperedIndices = goodProof.pathIndices!.slice();
+        tamperedIndices[level] = (tamperedIndices[level]! ^ 1) & 1;
+        const tamperedProof: MerkleProof = {
+          ...goodProof,
+          pathIndices: tamperedIndices,
+        };
+
+        const recomputed = recomputeRoot(tamperedProof, leafBytes);
+        expect(recomputed.equals(expectedRoot)).toBe(false);
+      },
+    );
+  });
+
+  it("distinguishes value mutation from index mutation at the same level", () => {
+    const { tree, leafBytes, goodProof } = buildScenario(7);
+    const expectedRoot = tree.getRoot();
+
+    const valueTamper: MerkleProof = {
+      ...goodProof,
+      pathElements: goodProof.pathElements.map((sibling, i) =>
+        i === 0 ? flipFirstByte(sibling) : Buffer.from(sibling),
+      ),
+    };
+    const indexTamper: MerkleProof = {
+      ...goodProof,
+      pathIndices: goodProof.pathIndices!.map((bit, i) =>
+        i === 0 ? ((bit ^ 1) & 1) : bit,
+      ),
+    };
+
+    // Both must miss the published root, and they must miss it via different
+    // computed values — that's the point of the regression matrix: an
+    // implementation that confuses index/value bugs would produce identical
+    // recomputed roots here.
+    const v = recomputeRoot(valueTamper, leafBytes);
+    const i = recomputeRoot(indexTamper, leafBytes);
+    expect(v.equals(expectedRoot)).toBe(false);
+    expect(i.equals(expectedRoot)).toBe(false);
+    expect(v.equals(i)).toBe(false);
+  });
+});

--- a/sdk/test/withdrawal_pool_id.test.ts
+++ b/sdk/test/withdrawal_pool_id.test.ts
@@ -1,0 +1,128 @@
+/// <reference types="jest" />
+import { Note } from "../src/note";
+import {
+  MerkleProof,
+  ProofGenerator,
+  PreparedWitness,
+} from "../src/proof";
+import { buildWithdrawalProofCacheKey } from "../src/withdraw";
+import { WITHDRAWAL_PUBLIC_INPUT_SCHEMA } from "../src/encoding";
+import { assertValidPreparedWithdrawalWitness } from "../src/witness";
+
+/**
+ * ZK-029: pool_id MUST be a first-class part of the withdrawal witness and
+ * proof shape. These tests pin the cross-stack invariants documented in the
+ * issue acceptance criteria:
+ *
+ *   1. Witness preparation requires a pool identifier (sourced from `note.poolId`).
+ *   2. Proof fixtures differ when only pool_id changes (everything else equal).
+ *   3. The withdrawal circuit and SDK witness schema stay aligned —
+ *      `pool_id` is at index 0 of `WITHDRAWAL_PUBLIC_INPUT_SCHEMA` and
+ *      mirrored in `circuits/withdraw/src/main.nr`.
+ */
+
+const RECIPIENT = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+function buildNote(poolId: string): Note {
+  return new Note(
+    Buffer.from("01".repeat(31), "hex"),
+    Buffer.from("02".repeat(31), "hex"),
+    poolId,
+    1000n,
+  );
+}
+
+function buildMerkleProof(): MerkleProof {
+  return {
+    root: Buffer.from("04".repeat(32), "hex"),
+    pathElements: Array.from({ length: 20 }, (_, i) =>
+      Buffer.from((5 + i).toString(16).padStart(2, "0").repeat(32), "hex"),
+    ),
+    pathIndices: Array.from({ length: 20 }, () => 0),
+    leafIndex: 0,
+  };
+}
+
+async function prepareFor(poolId: string): Promise<PreparedWitness> {
+  return ProofGenerator.prepareWitness(
+    buildNote(poolId),
+    buildMerkleProof(),
+    RECIPIENT,
+  );
+}
+
+describe("Withdrawal proof pool_id (ZK-029)", () => {
+  it("schema places pool_id at index 0 (matches circuits/withdraw/src/main.nr)", () => {
+    expect(WITHDRAWAL_PUBLIC_INPUT_SCHEMA[0]).toBe("pool_id");
+  });
+
+  it("prepared witness exposes a non-empty pool_id field", async () => {
+    const witness = await prepareFor("aa".repeat(32));
+    expect(typeof witness.pool_id).toBe("string");
+    expect(witness.pool_id).toMatch(/^[0-9a-f]{64}$/);
+    expect(witness.pool_id).not.toBe("0".repeat(64));
+  });
+
+  it("witness validation rejects a witness whose pool_id is not a canonical field hex string", async () => {
+    const good = await prepareFor("aa".repeat(32));
+    const bad: PreparedWitness = { ...good, pool_id: "not-a-hex-string" };
+    expect(() => assertValidPreparedWithdrawalWitness(bad)).toThrow();
+  });
+
+  it("differing pool_ids produce differing prepared witnesses (everything else equal)", async () => {
+    const a = await prepareFor("aa".repeat(32));
+    const b = await prepareFor("bb".repeat(32));
+
+    expect(a.pool_id).not.toBe(b.pool_id);
+
+    // Every other field must be identical so the test isolates pool_id.
+    for (const key of WITHDRAWAL_PUBLIC_INPUT_SCHEMA) {
+      if (key === "pool_id") continue;
+      expect(a[key]).toBe(b[key]);
+    }
+    expect(a.nullifier).toBe(b.nullifier);
+    expect(a.secret).toBe(b.secret);
+    expect(a.leaf_index).toBe(b.leaf_index);
+    expect(a.hash_path).toEqual(b.hash_path);
+  });
+
+  it("differing pool_ids yield different cache keys (proof fixtures diverge)", async () => {
+    const note1 = buildNote("aa".repeat(32));
+    const note2 = buildNote("bb".repeat(32));
+    const merkleProof = buildMerkleProof();
+
+    const witness1 = await ProofGenerator.prepareWitness(note1, merkleProof, RECIPIENT);
+    const witness2 = await ProofGenerator.prepareWitness(note2, merkleProof, RECIPIENT);
+
+    const key1 = buildWithdrawalProofCacheKey(
+      { note: note1, merkleProof, recipient: RECIPIENT },
+      witness1,
+    );
+    const key2 = buildWithdrawalProofCacheKey(
+      { note: note2, merkleProof, recipient: RECIPIENT },
+      witness2,
+    );
+
+    expect(key1).not.toBe(key2);
+  });
+
+  it("identical pool_ids yield identical cache keys (cache stays warm)", async () => {
+    const merkleProof = buildMerkleProof();
+    const note1 = buildNote("aa".repeat(32));
+    const note2 = buildNote("aa".repeat(32));
+
+    const witness1 = await ProofGenerator.prepareWitness(note1, merkleProof, RECIPIENT);
+    const witness2 = await ProofGenerator.prepareWitness(note2, merkleProof, RECIPIENT);
+
+    const key1 = buildWithdrawalProofCacheKey(
+      { note: note1, merkleProof, recipient: RECIPIENT },
+      witness1,
+    );
+    const key2 = buildWithdrawalProofCacheKey(
+      { note: note2, merkleProof, recipient: RECIPIENT },
+      witness2,
+    );
+
+    expect(key1).toBe(key2);
+  });
+});

--- a/sdk/test/witness_mutation.test.ts
+++ b/sdk/test/witness_mutation.test.ts
@@ -155,7 +155,7 @@ describe("Fixture mutation contract (one dimension per case)", () => {
     ).toThrow(ProvingError);
   });
 
-  it('ProofGenerator.formatProof rejects missing public inputs before formatting completes', () => {
+  it("ProofGenerator.formatProof rejects missing public inputs before formatting completes", () => {
     expect(() =>
       ProofGenerator.formatProof(new Uint8Array(GROTH16_PROOF_BYTE_LENGTH), {
         root: good.root,
@@ -164,11 +164,7 @@ describe("Fixture mutation contract (one dimension per case)", () => {
         amount: good.amount,
         relayer: good.relayer,
         fee: good.fee,
-      } as any)
-    ).toThrow('Invalid withdrawal public-input schema');
-  it("ProofGenerator.formatProof rejects under-long proof", () => {
-    expect(() => ProofGenerator.formatProof(new Uint8Array(1))).toThrow(
-      WitnessValidationError,
-    );
+      } as any),
+    ).toThrow("Invalid withdrawal public-input schema");
   });
 });


### PR DESCRIPTION
## Summary

Closes all four ZK-1 issues assigned to me in one PR. Before any of the substantive work could land, the SDK had to be unstuck — a recent main merge (\`9c97b99\`) left syntactic conflict residue in \`proof.ts\`, \`withdraw.ts\`, \`witness.ts\`, and two test files, so the whole SDK refused to compile. The first half of this PR removes that residue without changing intent; the second half adds the work for each issue.

### ZK-023 / #267 — Client-side Merkle sync format
- \`sdk/docs/MERKLE_SYNC_FORMAT.md\` — schema, three determinism guarantees (sequential==batch, round-trip preservation, mid-history resumability), optional \`leaves[]\` payload for proof generation, version-bump discipline
- \`sdk/test/merkle_sync_format.test.ts\` — 9 tests pinning each guarantee + JSON round-trip + frontier/depth mismatch rejection

### ZK-025 / #269 — Empty-tree / bootstrap-root fixtures
- New \`computeMerkleZeroLadder(depth)\` and \`generateBootstrapRootFixtures(classes, depth)\` derive canonical empty roots from the SDK's zero-node ladder — no hand-entered values
- \`sdk/test/empty_tree_fixtures.test.ts\` — 8 tests covering ladder shape, all-zero leaf baseline, equality with a freshly-instantiated \`LocalMerkleTree\`, determinism, multi-class fixture coverage, SDK init from the fixture

### ZK-027 / #271 — Full-level sibling tamper matrix
- \`sdk/test/merkle_tamper_matrix.test.ts\` — mutates exactly one sibling per level for **both** left and right leaf positions, **and** flips the index bit instead of the sibling value, **and** asserts that value-mutation vs index-mutation produce *distinct* failures (so an implementation that confuses the two can't pass)
- 2 × 20 levels × 2 (value/index) + 2 anchors = **82 tests**, all green

### ZK-029 / #273 — \`pool_id\` in withdrawal proof schema
- \`pool_id\` was already wired through circuit + SDK at \`circuits/withdraw/src/main.nr:50\`, \`WITHDRAWAL_PUBLIC_INPUT_SCHEMA[0]\`, witness preparation, and cache material — but the contract wasn't pinned anywhere
- \`sdk/test/withdrawal_pool_id.test.ts\` — schema position, non-empty witness field, malformed-\`pool_id\` rejection, **fixture divergence when only \`pool_id\` differs** (witness + cache key both diverge), and identical \`pool_id\` keeps the cache warm. 6 tests, all green.

## Merge cleanup (prerequisite)

| File | What was wrong | Fix |
|---|---|---|
| \`sdk/src/withdraw.ts\` | duplicate import block, single/double-quote duplicate function signatures, orphan old \`buildCacheMaterial\` body | rewrote to keep merged-in \`serializeWithdrawalPublicInputs\`-based cache material that already threads pool/denomination |
| \`sdk/src/proof.ts\` | missing \`}\` closing \`canonicalizePreparedWitness\` (cascaded into 30+ parse errors) | restored the brace |
| \`sdk/src/witness.ts\` | orphan stub of \`assertValidPreparedWithdrawalWitness\` concatenated with new function | removed stub, restored its \`pool_id\` assertion onto the surviving function |
| \`sdk/src/zk_constants.ts\` | \`STELLAR_ZERO_ACCOUNT\` referenced from \`proof.ts\` but never defined | added the canonical Stellar zero-account strkey |
| \`sdk/test/witness_mutation.test.ts\` | duplicate \`formatProof\` test bodies, missing \`})\` | dedupe + close |
| \`sdk/test/golden_vectors.test.ts\` | duplicate \`} from "../src/encoding"\` import + duplicate \`it(...)\` declaration | dedupe |

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx jest\` against the new suites — 105 / 105 new tests pass (9 + 8 + 82 + 6)
- [x] \`npx jest test/golden_vectors.test.ts\` — 40 restored tests pass (couldn't compile before this PR)
- [x] Full SDK suite: 182 passed / 13 failed. The 13 failures (zk_integration, witness_malformed, privacy_surface, merkle_root_validation, proof_cache invalidate-when-public-inputs-change) are pre-existing test-data drift from the same broken merge — invalid Stellar strkeys in fixtures, oversized field hex strings, etc. Out of scope here so this PR doesn't grow.

Closes #267
Closes #269
Closes #271
Closes #273