### PR TITLE
#374 ZK-098: Add a manifest-aware off-chain verification helper that rejects schema mismatch first

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -9,6 +9,7 @@
     "test": "jest",
     "test:smoke": "jest zk_smoke.test.ts --verbose",
     "test:schema-parity": "jest schema_parity.test.ts --verbose",
+    "test:zk-106": "jest hash_mode.test.ts proof_abstraction.test.ts --verbose",
     "test:zk-107": "jest zk_smoke.test.ts --verbose",
     "test:zk-108": "jest schema_parity.test.ts --verbose"
   },

--- a/sdk/src/encoding.ts
+++ b/sdk/src/encoding.ts
@@ -128,7 +128,12 @@ export function merkleNodeToField(buf: Buffer): string {
  *
  * The Stellar address is hashed with SHA-256 and the digest is reduced modulo
  * the BN254 field prime, producing a deterministic field-sized value.  This
- * mirrors the on-chain address_decoder used in the Soroban contract.
+ * mirrors the on-chain `address_decoder` used in the Soroban contract, which
+ * also uses SHA-256.  The output is therefore circuit-compatible for the
+ * `recipient` and `relayer` fields.
+ *
+ * @hash-mode SHA-256 (matches on-chain contract — circuit-compatible for address fields)
+ * @see contracts/privacy_pool/src/utils/address_decoder.rs
  */
 export function stellarAddressToField(address: string): string {
   if (!StrKey.isValidEd25519PublicKey(address)) {
@@ -139,19 +144,24 @@ export function stellarAddressToField(address: string): string {
 }
 
 /**
- * Compute the domain-separated nullifier hash: H(DOMAIN, nullifier, root).
+ * Compute the domain-separated nullifier hash: H(DOMAIN, nullifier, pool_id).
  *
  * The withdrawal circuit defines (circuits/lib/src/hash/nullifier.nr):
- *   nullifier_hash = pedersen_hash([NULLIFIER_DOMAIN_SEP, nullifier, root])
+ *   nullifier_hash = pedersen_hash([NULLIFIER_DOMAIN_SEP, nullifier, pool_id])
  *
  * The domain separator prevents cross-domain hash conflation between the
  * nullifier and commitment hash domains.
  *
- * This SDK implementation uses SHA-256 as a structural stand-in for the
- * BN254 Pedersen hash.  Replace with a real BN254 Pedersen implementation
- * (e.g. @noir-lang/barretenberg) before running against a real prover.
- * The input layout (domain ‖ nullifier ‖ root) mirrors the Noir circuit
- * so that both stacks are structurally equivalent.
+ * @mock-hash ZK-106 — This SDK implementation uses **SHA-256 as a structural
+ * stand-in** for the BN254 Pedersen hash used by the Noir circuit.  The input
+ * layout (DOMAIN ‖ nullifier ‖ pool_id) mirrors the circuit, but the hash
+ * function is different, so the output values diverge from what a real prover
+ * expects.  Do NOT use the result of this function in a witness destined for a
+ * real Barretenberg/Noir prover.  See {@link HashMode} and ZK-009/ZK-017 for
+ * the live-hash replacement path.
+ *
+ * Note: the second parameter is named `rootField` for historical reasons but
+ * should be the pool_id field (ZK-035 pool-scoped nullifier).
  */
 export function computeNullifierHash(nullifierField: string, rootField: string): string {
   const input = Buffer.concat([

--- a/sdk/src/hash_mode.ts
+++ b/sdk/src/hash_mode.ts
@@ -1,0 +1,92 @@
+/**
+ * ZK-106: Explicit hash mode abstraction for SDK helpers.
+ *
+ * Several SDK helpers compute nullifier hashes and Stellar address field
+ * encodings using SHA-256 as a **structural stand-in** for the BN254
+ * Poseidon2/Pedersen hash functions used by the Noir withdrawal circuit.
+ * These are labelled "mock" hash implementations:
+ *
+ *   - They preserve the correct input order and domain-separation layout.
+ *   - They produce DIFFERENT output values than the Noir circuit.
+ *   - They are suitable for unit tests that verify schema ordering, field
+ *     encoding, and structural invariants.
+ *   - They are INCOMPATIBLE with real Noir/Barretenberg proof generation:
+ *     a witness built from SHA-256 nullifier hashes will fail circuit
+ *     verification even if the Groth16 proof otherwise looks correct.
+ *
+ * LIVE mode is reserved for when a real BN254 Pedersen/Poseidon implementation
+ * is wired in (see ZK-009, ZK-017). Until then, all proof generation that
+ * passes through `ProofGenerator.generate()` must explicitly opt in with
+ * `{ testOnlyAllowMockHash: true }` to confirm the test knowingly operates
+ * on structural stand-in hashes.
+ *
+ * Affected functions (mock-hash):
+ *   - encoding.ts :: computeNullifierHash        (SHA-256 ≠ circuit Pedersen)
+ *   - encoding.ts :: stellarAddressToField        (SHA-256 — matches on-chain, but labelled for audit)
+ *   - public_inputs.ts :: encodeNullifierHash     (SHA-256 ≠ circuit Pedersen)
+ *
+ * @see sdk/src/encoding.ts
+ * @see sdk/src/public_inputs.ts
+ * @see sdk/src/proof.ts (ProofGenerator.prepareWitness, ProofGenerator.generate)
+ */
+
+/**
+ * HashMode discriminates between SHA-256 structural stand-ins (mock) and
+ * the real BN254 Poseidon2/Pedersen hash path (live).
+ *
+ * - `'mock'` — SHA-256-based implementations.  Fast, deterministic, but
+ *   incompatible with the on-chain withdrawal circuit.  Use in tests only.
+ * - `'live'` — Real BN254 implementations required for valid on-chain proofs.
+ *   Not yet fully wired; tracked by ZK-009 and ZK-017.
+ */
+export type HashMode = 'mock' | 'live';
+
+/**
+ * Sentinel constant for test files.
+ *
+ * Import `MOCK_HASH_CONTEXT` and pass it to `testOnlyAllowMockHash` to make
+ * mock-hash intent explicit at the call site.  Using a named import is
+ * intentionally more visible than a bare `true` literal.
+ *
+ * @example
+ * ```ts
+ * import { MOCK_HASH_CONTEXT } from '../src/hash_mode';
+ * // HASH_MODE: mock (ZK-106) — SHA-256 structural stand-ins
+ * const proof = await generateWithdrawalProof(
+ *   request,
+ *   backend,
+ *   { testOnlyAllowMockHash: MOCK_HASH_CONTEXT },
+ * );
+ * ```
+ */
+export const MOCK_HASH_CONTEXT: true = true;
+
+/**
+ * Guard: throw a descriptive error when a mock-hash witness is about to enter
+ * a proof-generation path without an explicit test-only opt-in.
+ *
+ * This prevents production code from accidentally producing proofs whose
+ * public inputs were derived from SHA-256 rather than the BN254 Pedersen/
+ * Poseidon hash that the Noir circuit expects.
+ *
+ * @param mode    - HashMode recorded on the PreparedWitness ('mock' | 'live' | undefined).
+ * @param location - Human-readable callsite label (e.g. 'ProofGenerator.generate').
+ * @param allowed  - When true (tests pass `testOnlyAllowMockHash: true`), the
+ *                   guard is bypassed so structural/integration tests can run.
+ */
+export function assertNotMockHashMode(
+  mode: HashMode | undefined,
+  location: string,
+  allowed: boolean = false,
+): void {
+  if (mode === 'mock' && !allowed) {
+    throw new Error(
+      `[ZK-106] ${location}: witness was prepared with mock-hash mode ` +
+        `(SHA-256 structural stand-ins). ` +
+        `A real Noir/Barretenberg prover requires Poseidon2/Pedersen nullifier hashes — ` +
+        `a SHA-256-derived nullifier_hash will not satisfy the circuit constraints. ` +
+        `If this is a test, pass { testOnlyAllowMockHash: true } explicitly. ` +
+        `For production proof generation, rebuild the witness with a live hash implementation.`,
+    );
+  }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,6 +1,7 @@
 export * from './backends';
 export * from './benchmark';
 export * from './encoding';
+export * from './offline_verify';
 export * from './errors';
 export * from './hash_mode';
 export * from './merkle';

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -2,6 +2,7 @@ export * from './backends';
 export * from './benchmark';
 export * from './encoding';
 export * from './errors';
+export * from './hash_mode';
 export * from './merkle';
 export * from './note';
 export * from './proof';

--- a/sdk/src/offline_verify.ts
+++ b/sdk/src/offline_verify.ts
@@ -1,0 +1,238 @@
+/**
+ * ZK-098: Manifest-Aware Off-Chain Verification Helper
+ *
+ * Off-chain verification is more useful when it can explain *why* it failed.
+ * This module adds a pre-verification layer that checks artifact provenance
+ * and public-input schema before delegating to the cryptographic backend.
+ *
+ * Failure categories (OfflineVerificationFailureCategory):
+ *
+ *   BAD_ARTIFACT — The supplied artifact set does not match the manifest.
+ *                  Indicates a bytecode, ABI, circuit-ID, or path mismatch.
+ *                  Detected before any cryptography is attempted.
+ *
+ *   BAD_SCHEMA   — The manifest's declared public-input schema is
+ *                  incompatible with the SDK's WITHDRAWAL_PUBLIC_INPUT_SCHEMA,
+ *                  or the caller passed a raw string[] instead of named fields
+ *                  so canonical field ordering cannot be enforced.
+ *
+ *   BAD_PROOF    — The artifact set and schema are consistent but the
+ *                  Groth16 / Barretenberg backend rejected the proof.
+ *
+ * The entry-point function `verifyWithManifest` only resolves (returns true)
+ * when all three layers pass.  Every failure path throws an
+ * `OfflineVerificationError` with a stable `category` field so callers can
+ * branch on failure kind without string-matching error messages.
+ *
+ * @see sdk/src/backends/noir.ts  — assertManifestMatchesNoirArtifacts
+ * @see sdk/src/encoding.ts       — WITHDRAWAL_PUBLIC_INPUT_SCHEMA
+ * @see sdk/src/withdraw.ts       — buildWithdrawalPublicInputLayout
+ */
+
+import { VerifyingBackend, PreparedWitness } from './proof';
+import { WithdrawalPublicInputs, WITHDRAWAL_PUBLIC_INPUT_SCHEMA } from './encoding';
+import { buildWithdrawalPublicInputLayout } from './withdraw';
+import {
+  NoirArtifacts,
+  ZkArtifactManifest,
+  ZkArtifactManifestCircuit,
+  assertManifestMatchesNoirArtifacts,
+  ArtifactManifestError,
+} from './backends/noir';
+
+// ---------------------------------------------------------------------------
+// Failure taxonomy
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable failure categories emitted by `verifyWithManifest`.
+ *
+ * | Category       | Root cause                                             |
+ * |----------------|--------------------------------------------------------|
+ * | BAD_ARTIFACT   | Bytecode/ABI/path/circuit-ID mismatch vs manifest      |
+ * | BAD_SCHEMA     | Public-input schema incompatible with manifest/SDK     |
+ * | BAD_PROOF      | Cryptographic verification rejected the proof          |
+ */
+export type OfflineVerificationFailureCategory =
+  | 'BAD_ARTIFACT'
+  | 'BAD_SCHEMA'
+  | 'BAD_PROOF';
+
+/**
+ * Thrown by `verifyWithManifest` for all failure paths.
+ * Inspect `.category` to determine the failure kind without
+ * parsing error messages.
+ */
+export class OfflineVerificationError extends Error {
+  constructor(
+    message: string,
+    public readonly category: OfflineVerificationFailureCategory,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'OfflineVerificationError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface OfflineVerifyOptions {
+  /**
+   * Optional artifact file path to cross-check against the manifest entry.
+   * When supplied, the manifest's `path` field for the circuit must match.
+   * Omit to skip path validation.
+   */
+  artifactPath?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compares the manifest's declared public-input schema against the SDK's
+ * canonical `WITHDRAWAL_PUBLIC_INPUT_SCHEMA`.
+ * Throws `OfflineVerificationError(BAD_SCHEMA)` if they diverge.
+ */
+function assertSchemaCompatible(
+  circuitName: string,
+  manifestCircuit: ZkArtifactManifestCircuit,
+): void {
+  const { public_input_schema: manifestSchema } = manifestCircuit;
+  if (!manifestSchema || manifestSchema.length === 0) {
+    // Manifest does not declare a schema — skip comparison.
+    return;
+  }
+
+  const sdkSchema = Array.from(WITHDRAWAL_PUBLIC_INPUT_SCHEMA);
+
+  if (
+    manifestSchema.length !== sdkSchema.length ||
+    manifestSchema.some((field, i) => field !== sdkSchema[i])
+  ) {
+    throw new OfflineVerificationError(
+      `Public-input schema mismatch for circuit "${circuitName}": ` +
+        `manifest declares [${manifestSchema.join(', ')}] ` +
+        `but SDK expects [${sdkSchema.join(', ')}]`,
+      'BAD_SCHEMA',
+    );
+  }
+}
+
+/**
+ * Guard that rejects a raw `string[]` at the public-inputs boundary.
+ * A named-field object is required so canonical schema ordering can be
+ * enforced without ambiguity.
+ */
+function assertNamedPublicInputs(
+  publicInputs: WithdrawalPublicInputs | PreparedWitness | string[],
+): asserts publicInputs is WithdrawalPublicInputs | PreparedWitness {
+  if (Array.isArray(publicInputs)) {
+    throw new OfflineVerificationError(
+      'Public inputs must be provided as named fields (WithdrawalPublicInputs or PreparedWitness), ' +
+        'not a raw string[]. Schema ordering cannot be enforced without field names.',
+      'BAD_SCHEMA',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Primary entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * verifyWithManifest
+ *
+ * Manifest-aware off-chain verification helper (ZK-098).
+ *
+ * Performs three ordered checks before accepting a proof as valid:
+ *
+ * 1. **Artifact check** — Validates bytecode, ABI, circuit-ID, name, and
+ *    (optionally) artifact path against the loaded manifest.  Throws
+ *    `OfflineVerificationError('BAD_ARTIFACT')` on any mismatch.
+ *
+ * 2. **Schema check** — If the manifest circuit entry carries a
+ *    `public_input_schema`, it must exactly match
+ *    `WITHDRAWAL_PUBLIC_INPUT_SCHEMA`.  Raw `string[]` inputs are also
+ *    rejected here.  Throws `OfflineVerificationError('BAD_SCHEMA')`.
+ *
+ * 3. **Cryptographic check** — Delegates to the injected `VerifyingBackend`.
+ *    Both a `false` return value and a thrown exception are normalised to
+ *    `OfflineVerificationError('BAD_PROOF')`.
+ *
+ * @param proof         Proof bytes to verify.
+ * @param publicInputs  Named withdrawal public inputs (not raw string[]).
+ * @param artifacts     Compiled circuit artifacts (bytecode / ABI / vkey).
+ * @param manifest      Loaded ZK artifact manifest.
+ * @param circuitName   Key in `manifest.circuits` to validate against.
+ * @param backend       Verifying backend instance.
+ * @param options       Optional artifact path for extra manifest cross-check.
+ *
+ * @returns `true` — only resolves when all three checks pass.
+ * @throws  `OfflineVerificationError` for any failure.
+ */
+export async function verifyWithManifest(
+  proof: Uint8Array,
+  publicInputs: WithdrawalPublicInputs | PreparedWitness | string[],
+  artifacts: NoirArtifacts,
+  manifest: ZkArtifactManifest,
+  circuitName: string,
+  backend: VerifyingBackend,
+  options: OfflineVerifyOptions = {},
+): Promise<true> {
+  // ------------------------------------------------------------------
+  // Step 1: Artifact provenance check
+  // ------------------------------------------------------------------
+  let manifestCircuit: ZkArtifactManifestCircuit;
+  try {
+    manifestCircuit = assertManifestMatchesNoirArtifacts(
+      manifest,
+      circuitName,
+      artifacts,
+      options.artifactPath,
+    );
+  } catch (err) {
+    if (err instanceof ArtifactManifestError) {
+      throw new OfflineVerificationError(err.message, 'BAD_ARTIFACT', err);
+    }
+    // Re-wrap unexpected errors so callers always receive OfflineVerificationError.
+    throw new OfflineVerificationError(
+      `Unexpected artifact validation error: ${err instanceof Error ? err.message : String(err)}`,
+      'BAD_ARTIFACT',
+      err,
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Step 2: Public-input schema check
+  // ------------------------------------------------------------------
+  assertNamedPublicInputs(publicInputs);
+  assertSchemaCompatible(circuitName, manifestCircuit);
+
+  // ------------------------------------------------------------------
+  // Step 3: Cryptographic verification
+  // ------------------------------------------------------------------
+  const inputLayout = buildWithdrawalPublicInputLayout(publicInputs);
+
+  let verified: boolean;
+  try {
+    verified = await backend.verifyProof(proof, inputLayout.fields, artifacts);
+  } catch (err) {
+    throw new OfflineVerificationError(
+      `Proof verification backend error: ${err instanceof Error ? err.message : String(err)}`,
+      'BAD_PROOF',
+      err,
+    );
+  }
+
+  if (!verified) {
+    throw new OfflineVerificationError(
+      'Proof verification failed: proof is invalid for the supplied public inputs',
+      'BAD_PROOF',
+    );
+  }
+
+  return true;
+}

--- a/sdk/src/proof.ts
+++ b/sdk/src/proof.ts
@@ -9,6 +9,7 @@ import {
   serializeWithdrawalPublicInputs,
   stellarAddressToField,
 } from "./encoding";
+import { HashMode, assertNotMockHashMode } from "./hash_mode";
 import { WitnessValidationError } from "./errors";
 import {
   assertValidGroth16ProofBytes,
@@ -27,7 +28,13 @@ export type ProvingErrorCode =
   | "ARTIFACT_ERROR"
   | "WITNESS_ERROR"
   | "BACKEND_ERROR"
-  | "FORMATTING_ERROR";
+  | "FORMATTING_ERROR"
+  /**
+   * ZK-106: Thrown when `generate()` is called with a mock-hash witness
+   * (SHA-256 structural stand-in) without an explicit test-only opt-in.
+   * Pass `{ testOnlyAllowMockHash: true }` in tests to bypass this guard.
+   */
+  | "MOCK_HASH_MODE";
 
 /**
  * ProvingError
@@ -148,6 +155,12 @@ export interface VerifyingBackend {
  * Strongly-typed witness ready for the withdrawal circuit entrypoint defined
  * in circuits/withdraw/src/main.nr.  All field values are canonical 64-char
  * hex strings (32 bytes, big-endian, no 0x prefix).
+ *
+ * The `hashMode` field is SDK-only metadata (ZK-106) that records how the
+ * nullifier_hash was derived.  It is stripped by `canonicalizePreparedWitness`
+ * before the witness is passed to the proving backend, so it never enters the
+ * circuit.  `hashMode: 'mock'` means SHA-256 stand-ins were used; the witness
+ * cannot be used with a real prover without rebuilding with a live hash.
  */
 export interface PreparedWitness {
   // Private witnesses
@@ -164,6 +177,13 @@ export interface PreparedWitness {
   relayer: string;
   fee: string;
   denomination: string;
+  /**
+   * ZK-106: Records which hash mode was used to build this witness.
+   * 'mock'  — SHA-256 structural stand-ins (incompatible with real provers).
+   * 'live'  — Real BN254 Poseidon2/Pedersen (required for on-chain proofs).
+   * undefined — Legacy witness built before ZK-106 (treat as 'mock').
+   */
+  hashMode?: HashMode;
 }
 
 export const PREPARED_WITHDRAWAL_WITNESS_SCHEMA = [
@@ -201,6 +221,17 @@ function canonicalizePreparedWitness(witness: PreparedWitness): PreparedWitness 
 export interface WitnessPreparationOptions {
   merkleDepth?: number;
   denomination?: bigint;
+  /**
+   * ZK-106: Explicitly allow a mock-hash witness to reach `ProofGenerator.generate()`.
+   * Set to `true` ONLY in tests.  Production code MUST NOT set this flag — doing
+   * so will produce proof attempts that fail on-chain because the SHA-256-derived
+   * nullifier_hash does not match the Pedersen hash expected by the Noir circuit.
+   *
+   * Recommended pattern:
+   *   import { MOCK_HASH_CONTEXT } from './hash_mode';
+   *   await gen.generate(witness, { testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
+   */
+  testOnlyAllowMockHash?: true;
 }
 
 /**
@@ -247,6 +278,19 @@ export class ProofGenerator {
         "WITNESS_ERROR",
         e,
       );
+    }
+
+    // ZK-106: Guard against mock-hash witnesses entering a real proving backend.
+    // Witness validation runs first so structural errors (bad field length, etc.)
+    // surface as WITNESS_ERROR rather than being masked by this guard.
+    try {
+      assertNotMockHashMode(
+        (witness as PreparedWitness).hashMode,
+        'ProofGenerator.generate',
+        options.testOnlyAllowMockHash === true,
+      );
+    } catch (e: any) {
+      throw new ProvingError(e.message, 'MOCK_HASH_MODE', e);
     }
 
     try {
@@ -345,6 +389,9 @@ export class ProofGenerator {
       relayer: relayerField,
       fee: fieldToHex(fee),
       denomination: fieldToHex(expectedDenomination),
+      // ZK-106: Record that nullifier_hash was derived via SHA-256 (mock).
+      // This stamps the witness so that generate() can enforce the mock-hash guard.
+      hashMode: 'mock' as const,
     };
   }
 

--- a/sdk/src/public_inputs.ts
+++ b/sdk/src/public_inputs.ts
@@ -195,6 +195,13 @@ export function encodeDenomination(denomination: bigint): string {
  * ZK-035: Changed from root-bound to pool-scoped nullifier derivation.
  * Spend identifiers remain stable across historical roots for the same note and pool.
  * Cross-pool replays are rejected by construction since pool_id is part of the hash.
+ *
+ * @mock-hash ZK-106 — This implementation uses **SHA-256 as a structural stand-in**
+ * for the BN254 Pedersen hash used by the Noir withdrawal circuit.  The input layout
+ * (DOMAIN ‖ nullifier ‖ pool_id) mirrors the circuit, but the hash function differs,
+ * so outputs diverge from what a real prover expects.  Do NOT use the result in a
+ * witness for a real Barretenberg/Noir prover.  See {@link HashMode} in hash_mode.ts
+ * and ZK-009/ZK-017 for the live-hash replacement path.
  */
 export function encodeNullifierHash(nullifierField: string, poolIdField: string): string {
   const input = Buffer.concat([

--- a/sdk/src/withdraw.ts
+++ b/sdk/src/withdraw.ts
@@ -39,6 +39,12 @@ export interface WithdrawalProofGenerationOptions {
   cache?: ProofCache;
   cacheKey?: string;
   merkleDepth?: number;
+  /**
+   * ZK-106: Forward to `ProofGenerator.generate()` to allow a mock-hash witness
+   * through the production guard.  Set to `true` ONLY in tests.
+   * See {@link WitnessPreparationOptions.testOnlyAllowMockHash}.
+   */
+  testOnlyAllowMockHash?: true;
 }
 
 interface WithdrawalCacheMaterial {
@@ -155,6 +161,7 @@ export async function generateWithdrawalProof(
   const proofGenerator = new ProofGenerator(backend);
   const rawProof = await proofGenerator.generate(witness, {
     merkleDepth: options.merkleDepth,
+    testOnlyAllowMockHash: options.testOnlyAllowMockHash,
   });
 
   // 3. Format the proof for the Soroban contract

--- a/sdk/test/golden_vectors.test.ts
+++ b/sdk/test/golden_vectors.test.ts
@@ -13,6 +13,9 @@ import {
   WITHDRAWAL_PUBLIC_INPUT_SCHEMA,
 } from "../src/encoding";
 import { buildWithdrawalPublicInputLayout } from "../src/withdraw";
+// HASH_MODE: mock (ZK-106) — `computeNullifierHash` uses SHA-256 structural stand-ins.
+// Golden vector tests verify field encoding, schema order, and structural correctness.
+// No proof generation is performed; these tests are not circuit-compatibility checks.
 
 // ---------------------------------------------------------------------------
 // Load golden fixture

--- a/sdk/test/hash_mode.test.ts
+++ b/sdk/test/hash_mode.test.ts
@@ -1,0 +1,260 @@
+/**
+ * ZK-106: Hash Mode Guard Tests
+ *
+ * Verifies that the mock-hash / live-hash boundary is explicit and enforced:
+ *
+ *   1. `HashMode` type and `MOCK_HASH_CONTEXT` constant are exported correctly.
+ *   2. `assertNotMockHashMode` throws for mock mode without opt-in.
+ *   3. `assertNotMockHashMode` passes for live mode and the opt-in bypass.
+ *   4. `ProofGenerator.prepareWitness` stamps `hashMode: 'mock'` on the witness.
+ *   5. `ProofGenerator.generate()` rejects a mock-hash witness without opt-in.
+ *   6. `ProofGenerator.generate()` accepts a mock-hash witness with `testOnlyAllowMockHash: true`.
+ *   7. The proving backend receives a canonicalized witness that does NOT contain `hashMode`.
+ *
+ * Wave Issue Key: ZK-106
+ */
+
+// HASH_MODE: mock (ZK-106) — all proof operations in this file use SHA-256 stand-ins;
+// testOnlyAllowMockHash: true is set wherever generate() is exercised.
+
+import { Note } from '../src/note';
+import {
+  MerkleProof,
+  PreparedWitness,
+  ProofGenerator,
+  ProvingBackend,
+  ProvingError,
+  PREPARED_WITHDRAWAL_WITNESS_SCHEMA,
+} from '../src/proof';
+import {
+  HashMode,
+  MOCK_HASH_CONTEXT,
+  assertNotMockHashMode,
+} from '../src/hash_mode';
+import { DEFAULT_DENOMINATION } from '../src/zk_constants';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const RECIPIENT = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+// Use 0x03...03 — safely below the BN254 field modulus (0x30...) for Merkle nodes and pool IDs
+const r32 = Buffer.from('03'.repeat(32), 'hex');
+const s31 = () => Buffer.from('01'.repeat(31), 'hex');
+const p20 = () => Array.from({ length: 20 }, () => r32);
+
+function makeNote(): Note {
+  return new Note(s31(), s31(), '03'.repeat(32), DEFAULT_DENOMINATION);
+}
+
+function makeMerkleProof(): MerkleProof {
+  return { root: r32, pathElements: p20(), leafIndex: 0 };
+}
+
+class StubBackend implements ProvingBackend {
+  public receivedWitness: any = undefined;
+
+  async generateProof(witness: any): Promise<Uint8Array> {
+    this.receivedWitness = witness;
+    return new Uint8Array(256).fill(0xcd);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HashMode type and MOCK_HASH_CONTEXT constant
+// ---------------------------------------------------------------------------
+
+describe('ZK-106: HashMode type and MOCK_HASH_CONTEXT', () => {
+  it('MOCK_HASH_CONTEXT is the boolean true (used as testOnlyAllowMockHash value)', () => {
+    expect(MOCK_HASH_CONTEXT).toBe(true);
+  });
+
+  it('HashMode values are the string literals mock and live', () => {
+    const mock: HashMode = 'mock';
+    const live: HashMode = 'live';
+    expect(mock).toBe('mock');
+    expect(live).toBe('live');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertNotMockHashMode guard
+// ---------------------------------------------------------------------------
+
+describe('ZK-106: assertNotMockHashMode guard', () => {
+  it('throws for mock mode without opt-in', () => {
+    expect(() => assertNotMockHashMode('mock', 'test-location')).toThrow('[ZK-106]');
+  });
+
+  it('error message names the callsite location', () => {
+    expect(() => assertNotMockHashMode('mock', 'ProofGenerator.generate'))
+      .toThrow('ProofGenerator.generate');
+  });
+
+  it('error message mentions structural stand-in and opt-in flag', () => {
+    expect(() => assertNotMockHashMode('mock', 'x'))
+      .toThrow('testOnlyAllowMockHash: true');
+  });
+
+  it('does not throw for live mode', () => {
+    expect(() => assertNotMockHashMode('live', 'test-location')).not.toThrow();
+  });
+
+  it('does not throw when mode is undefined (legacy witness)', () => {
+    expect(() => assertNotMockHashMode(undefined, 'test-location')).not.toThrow();
+  });
+
+  it('does not throw for mock mode when allowed=true', () => {
+    expect(() => assertNotMockHashMode('mock', 'test-location', true)).not.toThrow();
+  });
+
+  it('MOCK_HASH_CONTEXT bypasses the guard as testOnlyAllowMockHash', () => {
+    expect(() => assertNotMockHashMode('mock', 'test', MOCK_HASH_CONTEXT)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareWitness stamps hashMode: 'mock'
+// ---------------------------------------------------------------------------
+
+describe('ZK-106: ProofGenerator.prepareWitness stamps hashMode', () => {
+  it("stamps hashMode: 'mock' on the returned PreparedWitness", async () => {
+    const witness = await ProofGenerator.prepareWitness(
+      makeNote(),
+      makeMerkleProof(),
+      RECIPIENT,
+    );
+    expect(witness.hashMode).toBe('mock');
+  });
+
+  it('hashMode is not in PREPARED_WITHDRAWAL_WITNESS_SCHEMA (circuit-facing schema is unchanged)', () => {
+    expect(PREPARED_WITHDRAWAL_WITNESS_SCHEMA).not.toContain('hashMode');
+  });
+
+  it('circuit-facing fields are all present alongside hashMode', async () => {
+    const witness = await ProofGenerator.prepareWitness(
+      makeNote(),
+      makeMerkleProof(),
+      RECIPIENT,
+    );
+    const circuitFields = Object.keys(witness).filter((k) => k !== 'hashMode');
+    expect(circuitFields.sort()).toEqual([...PREPARED_WITHDRAWAL_WITNESS_SCHEMA].sort());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generate() rejects mock-hash witnesses without opt-in
+// ---------------------------------------------------------------------------
+
+describe('ZK-106: ProofGenerator.generate() mock-hash guard', () => {
+  it('throws ProvingError with code MOCK_HASH_MODE for a mock-hash witness', async () => {
+    const backend = new StubBackend();
+    const gen = new ProofGenerator(backend);
+    const witness = await ProofGenerator.prepareWitness(
+      makeNote(),
+      makeMerkleProof(),
+      RECIPIENT,
+    );
+
+    // Without opt-in: must throw
+    await expect(gen.generate(witness)).rejects.toThrow(ProvingError);
+
+    let caughtCode: string | undefined;
+    try {
+      await gen.generate(witness);
+    } catch (e: any) {
+      caughtCode = (e as ProvingError).code;
+    }
+    expect(caughtCode).toBe('MOCK_HASH_MODE');
+  });
+
+  it('error message identifies mock-hash mode and mentions opt-in flag', async () => {
+    const gen = new ProofGenerator(new StubBackend());
+    const witness = await ProofGenerator.prepareWitness(
+      makeNote(),
+      makeMerkleProof(),
+      RECIPIENT,
+    );
+
+    await expect(gen.generate(witness)).rejects.toThrow('ZK-106');
+    await expect(gen.generate(witness)).rejects.toThrow('testOnlyAllowMockHash');
+  });
+
+  it('backend is never invoked when mock-hash guard fires', async () => {
+    const backend = new StubBackend();
+    const gen = new ProofGenerator(backend);
+    const witness = await ProofGenerator.prepareWitness(
+      makeNote(),
+      makeMerkleProof(),
+      RECIPIENT,
+    );
+
+    await gen.generate(witness, { testOnlyAllowMockHash: true }).catch(() => {});
+    const callsWithGuardFiring = 0; // guard fires = 0 invocations
+    const backendReceived = backend.receivedWitness;
+
+    // With guard bypassed, backend IS invoked
+    await gen.generate(witness, { testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
+    expect(backend.receivedWitness).toBeDefined();
+
+    // With guard active (no opt-in), backend is NOT invoked after a second gen
+    const backend2 = new StubBackend();
+    const gen2 = new ProofGenerator(backend2);
+    await gen2.generate(witness).catch(() => {});
+    expect(backend2.receivedWitness).toBeUndefined();
+  });
+
+  it('accepts mock-hash witness with testOnlyAllowMockHash: true', async () => {
+    const backend = new StubBackend();
+    const gen = new ProofGenerator(backend);
+    const witness = await ProofGenerator.prepareWitness(
+      makeNote(),
+      makeMerkleProof(),
+      RECIPIENT,
+    );
+
+    const proof = await gen.generate(witness, { testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
+    expect(proof).toBeInstanceOf(Uint8Array);
+    expect(proof.length).toBe(256);
+  });
+
+  it('accepts a witness with no hashMode (legacy, undefined) without guard', async () => {
+    const backend = new StubBackend();
+    const gen = new ProofGenerator(backend);
+
+    // Build a legacy witness manually (no hashMode field)
+    const base = await ProofGenerator.prepareWitness(
+      makeNote(),
+      makeMerkleProof(),
+      RECIPIENT,
+    );
+    const { hashMode: _removed, ...legacyWitness } = base;
+
+    // Legacy witness (hashMode=undefined) must NOT trigger the guard
+    const proof = await gen.generate(legacyWitness);
+    expect(proof).toBeInstanceOf(Uint8Array);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Backend receives canonicalized witness without hashMode
+// ---------------------------------------------------------------------------
+
+describe('ZK-106: canonicalized witness sent to backend has no hashMode', () => {
+  it('backend receives only circuit-facing fields (hashMode is stripped)', async () => {
+    const backend = new StubBackend();
+    const gen = new ProofGenerator(backend);
+    const witness = await ProofGenerator.prepareWitness(
+      makeNote(),
+      makeMerkleProof(),
+      RECIPIENT,
+    );
+
+    await gen.generate(witness, { testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
+
+    expect(backend.receivedWitness).toBeDefined();
+    expect(backend.receivedWitness).not.toHaveProperty('hashMode');
+    const backendKeys = Object.keys(backend.receivedWitness).sort();
+    expect(backendKeys).toEqual([...PREPARED_WITHDRAWAL_WITNESS_SCHEMA].sort());
+  });
+});

--- a/sdk/test/nullifier_domain.test.ts
+++ b/sdk/test/nullifier_domain.test.ts
@@ -6,6 +6,11 @@
  * (circuits/lib/src/hash/nullifier.nr), ensuring both stacks produce hashes
  * in the same domain and that the nullifier domain is disjoint from the
  * commitment domain.
+ *
+ * HASH_MODE: mock (ZK-106) — `computeNullifierHash` uses SHA-256 as a structural
+ * stand-in for the BN254 Pedersen hash used by the Noir circuit.  These tests
+ * verify domain separation and structural layout, NOT circuit-compatible output
+ * values.  No proof generation is performed in this suite.
  */
 
 import { createHash } from 'crypto';

--- a/sdk/test/offline_depth.test.ts
+++ b/sdk/test/offline_depth.test.ts
@@ -1,3 +1,6 @@
+// HASH_MODE: mock (ZK-106) — uses SHA-256 structural stand-ins via prepareWitness;
+// testOnlyAllowMockHash: MOCK_HASH_CONTEXT is set on the generateWithdrawalProof() call that is expected to succeed.
+
 import { Note } from "../src/note";
 import { ProofGenerator } from "../src/proof";
 import {
@@ -8,6 +11,7 @@ import {
 import { generateWithdrawalProof } from "../src/withdraw";
 import { WitnessValidationError } from "../src/errors";
 import { GROTH16_PROOF_BYTE_LENGTH } from "../src/witness";
+import { MOCK_HASH_CONTEXT } from "../src/hash_mode";
 
 const RECIPIENT = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 const POOL_ID = "11".repeat(32);
@@ -91,7 +95,8 @@ describe("Offline merkle depth support", () => {
       generateWithdrawalProof(
         { note, merkleProof: proof, recipient: RECIPIENT },
         backend,
-        { merkleDepth: depth },
+        // HASH_MODE: mock — testOnlyAllowMockHash acknowledges SHA-256 stand-ins
+        { merkleDepth: depth, testOnlyAllowMockHash: MOCK_HASH_CONTEXT },
       ),
     ).resolves.toBeInstanceOf(Buffer);
   });

--- a/sdk/test/offline_verify.test.ts
+++ b/sdk/test/offline_verify.test.ts
@@ -1,0 +1,410 @@
+/**
+ * ZK-098: Manifest-Aware Off-Chain Verification Helper Tests
+ *
+ * Covers:
+ *   - Successful verification when artifacts, schema, and proof are all valid
+ *   - BAD_ARTIFACT: bytecode mismatch, missing circuit entry, path mismatch
+ *   - BAD_SCHEMA: raw string[] inputs, manifest schema divergence
+ *   - BAD_PROOF: backend returns false, backend throws
+ */
+
+/// <reference types="jest" />
+import fs from 'fs';
+import path from 'path';
+import {
+  verifyWithManifest,
+  OfflineVerificationError,
+  OfflineVerificationFailureCategory,
+} from '../src/offline_verify';
+import {
+  NoirArtifacts,
+  ZkArtifactManifest,
+} from '../src/backends/noir';
+import { VerifyingBackend } from '../src/proof';
+import { WithdrawalPublicInputs } from '../src/encoding';
+
+// ---------------------------------------------------------------------------
+// Fixture setup
+// ---------------------------------------------------------------------------
+
+const artifactsDir = path.resolve(__dirname, '../../artifacts/zk');
+
+let manifest: ZkArtifactManifest;
+let withdrawArtifact: any;
+
+beforeAll(() => {
+  manifest = JSON.parse(fs.readFileSync(path.join(artifactsDir, 'manifest.json'), 'utf8'));
+  withdrawArtifact = JSON.parse(fs.readFileSync(path.join(artifactsDir, 'withdraw.json'), 'utf8'));
+});
+
+function buildArtifacts(overrides: Partial<NoirArtifacts> = {}): NoirArtifacts {
+  return {
+    acir: Buffer.from(withdrawArtifact.bytecode, 'utf8'),
+    bytecode: withdrawArtifact.bytecode,
+    abi: withdrawArtifact.abi,
+    name: withdrawArtifact.name,
+    ...overrides,
+  };
+}
+
+// Use values that are safely below the BN254 field modulus (which starts ~0x30...).
+// Padding with 00 ensures they're small positive integers.
+const F0 = '00'.repeat(32);
+const F1 = '00'.repeat(31) + '01';
+const F2 = '00'.repeat(31) + '02';
+const F3 = '00'.repeat(31) + '03';
+const F4 = '00'.repeat(31) + '04';
+
+function makePublicInputs(overrides: Partial<WithdrawalPublicInputs> = {}): WithdrawalPublicInputs {
+  return {
+    pool_id: F1,
+    root: F2,
+    nullifier_hash: F3,
+    recipient: F4,
+    amount: '0000000000000000000000000000000000000000000000000000000000000064',
+    relayer: F0,
+    fee: F0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock backends
+// ---------------------------------------------------------------------------
+
+class AcceptingBackend implements VerifyingBackend {
+  async verifyProof(_proof: Uint8Array, _publicInputs: string[], _artifacts: any): Promise<boolean> {
+    return true;
+  }
+}
+
+class RejectingBackend implements VerifyingBackend {
+  async verifyProof(_proof: Uint8Array, _publicInputs: string[], _artifacts: any): Promise<boolean> {
+    return false;
+  }
+}
+
+class ThrowingBackend implements VerifyingBackend {
+  constructor(private readonly message: string = 'backend exploded') {}
+  async verifyProof(_proof: Uint8Array, _publicInputs: string[], _artifacts: any): Promise<boolean> {
+    throw new Error(this.message);
+  }
+}
+
+const VALID_PROOF = new Uint8Array(64).fill(0xab);
+const CIRCUIT_NAME = 'withdraw';
+const ARTIFACT_PATH = 'withdraw.json';
+
+// ---------------------------------------------------------------------------
+// Helper: assert OfflineVerificationError with expected category
+// ---------------------------------------------------------------------------
+async function expectCategory(
+  promise: Promise<unknown>,
+  category: OfflineVerificationFailureCategory,
+): Promise<void> {
+  let caught: unknown;
+  try {
+    await promise;
+    throw new Error('Expected OfflineVerificationError but none was thrown');
+  } catch (err) {
+    caught = err;
+  }
+  expect(caught).toBeInstanceOf(OfflineVerificationError);
+  expect((caught as OfflineVerificationError).category).toBe(category);
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe('ZK-098: verifyWithManifest — success path', () => {
+  it('resolves true when artifacts, schema, and proof are all valid', async () => {
+    const result = await verifyWithManifest(
+      VALID_PROOF,
+      makePublicInputs(),
+      buildArtifacts(),
+      manifest,
+      CIRCUIT_NAME,
+      new AcceptingBackend(),
+      { artifactPath: ARTIFACT_PATH },
+    );
+    expect(result).toBe(true);
+  });
+
+  it('succeeds without an explicit artifactPath option', async () => {
+    const result = await verifyWithManifest(
+      VALID_PROOF,
+      makePublicInputs(),
+      buildArtifacts(),
+      manifest,
+      CIRCUIT_NAME,
+      new AcceptingBackend(),
+    );
+    expect(result).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('ZK-098: verifyWithManifest — BAD_ARTIFACT', () => {
+  it('rejects when the circuit name is absent from the manifest', async () => {
+    const badManifest: ZkArtifactManifest = {
+      ...manifest,
+      circuits: { commitment: manifest.circuits.commitment },
+    };
+    await expectCategory(
+      verifyWithManifest(
+        VALID_PROOF,
+        makePublicInputs(),
+        buildArtifacts(),
+        badManifest,
+        CIRCUIT_NAME,
+        new AcceptingBackend(),
+      ),
+      'BAD_ARTIFACT',
+    );
+  });
+
+  it('rejects on bytecode hash mismatch', async () => {
+    await expectCategory(
+      verifyWithManifest(
+        VALID_PROOF,
+        makePublicInputs(),
+        buildArtifacts({ bytecode: withdrawArtifact.bytecode + '\n' }),
+        manifest,
+        CIRCUIT_NAME,
+        new AcceptingBackend(),
+      ),
+      'BAD_ARTIFACT',
+    );
+  });
+
+  it('rejects on ABI hash mismatch', async () => {
+    const tamperedAbi = { ...withdrawArtifact.abi, _tampered: true };
+    await expectCategory(
+      verifyWithManifest(
+        VALID_PROOF,
+        makePublicInputs(),
+        buildArtifacts({ abi: tamperedAbi }),
+        manifest,
+        CIRCUIT_NAME,
+        new AcceptingBackend(),
+      ),
+      'BAD_ARTIFACT',
+    );
+  });
+
+  it('rejects on artifact path mismatch', async () => {
+    await expectCategory(
+      verifyWithManifest(
+        VALID_PROOF,
+        makePublicInputs(),
+        buildArtifacts(),
+        manifest,
+        CIRCUIT_NAME,
+        new AcceptingBackend(),
+        { artifactPath: 'unexpected_path.json' },
+      ),
+      'BAD_ARTIFACT',
+    );
+  });
+
+  it('surfaces the original ArtifactManifestError cause', async () => {
+    const badManifest: ZkArtifactManifest = {
+      ...manifest,
+      circuits: {},
+    };
+    let caught: unknown;
+    try {
+      await verifyWithManifest(
+        VALID_PROOF,
+        makePublicInputs(),
+        buildArtifacts(),
+        badManifest,
+        CIRCUIT_NAME,
+        new AcceptingBackend(),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(OfflineVerificationError);
+    const err = caught as OfflineVerificationError;
+    expect(err.category).toBe('BAD_ARTIFACT');
+    expect(err.cause).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('ZK-098: verifyWithManifest — BAD_SCHEMA', () => {
+  it('rejects a raw string[] instead of named public inputs', async () => {
+    // Cast through unknown to simulate a caller passing the wrong type
+    const rawArray = ['pool_id', 'root', 'nullifier_hash', 'recipient', 'amount', 'relayer', 'fee'] as unknown as WithdrawalPublicInputs;
+    await expectCategory(
+      verifyWithManifest(
+        VALID_PROOF,
+        rawArray,
+        buildArtifacts(),
+        manifest,
+        CIRCUIT_NAME,
+        new AcceptingBackend(),
+      ),
+      'BAD_SCHEMA',
+    );
+  });
+
+  it('rejects when the manifest declares a schema that diverges from the SDK schema', async () => {
+    const badManifest: ZkArtifactManifest = {
+      ...manifest,
+      circuits: {
+        ...manifest.circuits,
+        [CIRCUIT_NAME]: {
+          ...manifest.circuits[CIRCUIT_NAME]!,
+          public_input_schema: [
+            'root',      // wrong order — root before pool_id
+            'pool_id',
+            'nullifier_hash',
+            'recipient',
+            'amount',
+            'relayer',
+            'fee',
+          ],
+        },
+      },
+    };
+
+    await expectCategory(
+      verifyWithManifest(
+        VALID_PROOF,
+        makePublicInputs(),
+        buildArtifacts(),
+        badManifest,
+        CIRCUIT_NAME,
+        new AcceptingBackend(),
+      ),
+      'BAD_SCHEMA',
+    );
+  });
+
+  it('rejects when the manifest schema has fewer fields than the SDK schema', async () => {
+    const badManifest: ZkArtifactManifest = {
+      ...manifest,
+      circuits: {
+        ...manifest.circuits,
+        [CIRCUIT_NAME]: {
+          ...manifest.circuits[CIRCUIT_NAME]!,
+          public_input_schema: ['pool_id', 'root', 'nullifier_hash'],
+        },
+      },
+    };
+
+    await expectCategory(
+      verifyWithManifest(
+        VALID_PROOF,
+        makePublicInputs(),
+        buildArtifacts(),
+        badManifest,
+        CIRCUIT_NAME,
+        new AcceptingBackend(),
+      ),
+      'BAD_SCHEMA',
+    );
+  });
+
+  it('skips schema check when manifest circuit has no public_input_schema', async () => {
+    const manifestWithoutSchema: ZkArtifactManifest = {
+      ...manifest,
+      circuits: {
+        ...manifest.circuits,
+        [CIRCUIT_NAME]: {
+          ...manifest.circuits[CIRCUIT_NAME]!,
+          public_input_schema: undefined,
+        },
+      },
+    };
+
+    const result = await verifyWithManifest(
+      VALID_PROOF,
+      makePublicInputs(),
+      buildArtifacts(),
+      manifestWithoutSchema,
+      CIRCUIT_NAME,
+      new AcceptingBackend(),
+    );
+    expect(result).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('ZK-098: verifyWithManifest — BAD_PROOF', () => {
+  it('throws BAD_PROOF when the backend returns false', async () => {
+    await expectCategory(
+      verifyWithManifest(
+        VALID_PROOF,
+        makePublicInputs(),
+        buildArtifacts(),
+        manifest,
+        CIRCUIT_NAME,
+        new RejectingBackend(),
+      ),
+      'BAD_PROOF',
+    );
+  });
+
+  it('throws BAD_PROOF when the backend throws an error', async () => {
+    await expectCategory(
+      verifyWithManifest(
+        VALID_PROOF,
+        makePublicInputs(),
+        buildArtifacts(),
+        manifest,
+        CIRCUIT_NAME,
+        new ThrowingBackend('groth16 failure'),
+      ),
+      'BAD_PROOF',
+    );
+  });
+
+  it('preserves the backend error as the cause', async () => {
+    let caught: unknown;
+    try {
+      await verifyWithManifest(
+        VALID_PROOF,
+        makePublicInputs(),
+        buildArtifacts(),
+        manifest,
+        CIRCUIT_NAME,
+        new ThrowingBackend('inner error'),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(OfflineVerificationError);
+    const err = caught as OfflineVerificationError;
+    expect(err.category).toBe('BAD_PROOF');
+    expect((err.cause as Error).message).toBe('inner error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('ZK-098: OfflineVerificationError — class invariants', () => {
+  it('has name OfflineVerificationError', () => {
+    const err = new OfflineVerificationError('msg', 'BAD_PROOF');
+    expect(err.name).toBe('OfflineVerificationError');
+  });
+
+  it('exposes category on the instance', () => {
+    const categories: OfflineVerificationFailureCategory[] = ['BAD_ARTIFACT', 'BAD_SCHEMA', 'BAD_PROOF'];
+    for (const cat of categories) {
+      const err = new OfflineVerificationError('test', cat);
+      expect(err.category).toBe(cat);
+    }
+  });
+
+  it('is an instance of Error', () => {
+    const err = new OfflineVerificationError('test', 'BAD_SCHEMA');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/sdk/test/pool_scoped_nullifier.test.ts
+++ b/sdk/test/pool_scoped_nullifier.test.ts
@@ -1,4 +1,7 @@
 /// <reference types="jest" />
+// HASH_MODE: mock (ZK-106) — `computeNullifierHash` uses SHA-256 structural stand-ins.
+// These tests verify pool-scoped nullifier stability and cross-pool isolation
+// at the structural level.  No proof generation is performed in this suite.
 import { Note } from '../src/note';
 import { MerkleProof, ProofGenerator } from '../src/proof';
 import { computeNullifierHash, poolIdToField, noteScalarToField } from '../src/encoding';

--- a/sdk/test/privacy_surface.test.ts
+++ b/sdk/test/privacy_surface.test.ts
@@ -9,6 +9,7 @@ import {
   ProvingBackend,
 } from '../src/proof';
 import { buildWithdrawalProofCacheKey, WithdrawalRequest } from '../src/withdraw';
+import { MOCK_HASH_CONTEXT } from '../src/hash_mode';
 
 const G = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 const RELAYER = 'GBZXN7PIRZGNMHGAH5Q4D5B4H3B7BWQ7M4CW67A4V6APSLW7M4Q6TLE5';
@@ -71,7 +72,8 @@ describe('Privacy surface regression', () => {
     expect(() => Note.deserialize(`${legacy}:debug-tag`)).toThrow('Invalid note format');
   });
 
-  it('prepareWitness emits only the circuit-facing witness schema', async () => {
+  it('prepareWitness emits circuit-facing schema fields plus hashMode metadata (ZK-106)', async () => {
+    // HASH_MODE: mock (ZK-106) — SHA-256 stand-ins; hashMode: 'mock' is stamped on the witness
     const witness = await ProofGenerator.prepareWitness(
       makeNote(),
       makeMerkleProof(),
@@ -80,13 +82,18 @@ describe('Privacy surface regression', () => {
       5n
     );
 
-    expect(Object.keys(witness).sort()).toEqual([...PREPARED_WITHDRAWAL_WITNESS_SCHEMA].sort());
+    // ZK-106: hashMode is the only permitted non-circuit metadata field on the witness.
+    // Circuit-facing fields must exactly match PREPARED_WITHDRAWAL_WITNESS_SCHEMA.
+    const circuitFields = Object.keys(witness).filter((k) => k !== 'hashMode');
+    expect(circuitFields.sort()).toEqual([...PREPARED_WITHDRAWAL_WITNESS_SCHEMA].sort());
+    expect(witness).toHaveProperty('hashMode', 'mock');
     expect(witness).not.toHaveProperty('path_indices');
     expect(witness).not.toHaveProperty('commitment');
     expect(witness).not.toHaveProperty('backup');
   });
 
   it('ProofGenerator.generate strips extra metadata before sending the witness to the backend', async () => {
+    // HASH_MODE: mock (ZK-106) — testOnlyAllowMockHash explicitly acknowledges SHA-256 stand-ins
     let backendWitness: PreparedWitness | undefined;
     const backend: ProvingBackend = {
       async generateProof(witness: PreparedWitness): Promise<Uint8Array> {
@@ -110,10 +117,12 @@ describe('Privacy surface regression', () => {
       exported_note: makeNote().exportBackup(),
     };
 
-    await new ProofGenerator(backend).generate(polluted);
+    await new ProofGenerator(backend).generate(polluted, { testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
 
     expect(backendWitness).toBeDefined();
+    // ZK-106: hashMode is stripped by canonicalizePreparedWitness; backend sees only circuit fields
     expect(Object.keys(backendWitness!).sort()).toEqual([...PREPARED_WITHDRAWAL_WITNESS_SCHEMA].sort());
+    expect(backendWitness).not.toHaveProperty('hashMode');
     expect(backendWitness).not.toHaveProperty('recipient_strkey');
     expect(backendWitness).not.toHaveProperty('debug_label');
     expect(backendWitness).not.toHaveProperty('exported_note');

--- a/sdk/test/proof_abstraction.test.ts
+++ b/sdk/test/proof_abstraction.test.ts
@@ -1,49 +1,77 @@
 /// <reference types="jest" />
+// HASH_MODE: mock (ZK-106) — uses SHA-256 structural stand-ins via prepareWitness;
+// testOnlyAllowMockHash: MOCK_HASH_CONTEXT is set on all generate() / generateWithdrawalProof() calls.
+
 import { Note } from '../src/note';
-import { MerkleProof, ProvingBackend } from '../src/proof';
+import { MerkleProof, ProofGenerator, ProvingBackend, ProvingError } from '../src/proof';
 import { generateWithdrawalProof } from '../src/withdraw';
+import { MOCK_HASH_CONTEXT } from '../src/hash_mode';
+import { DEFAULT_DENOMINATION } from '../src/zk_constants';
+
+const RECIPIENT = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const r32 = Buffer.from('03'.repeat(32), 'hex');
+const s31 = (byte = '01') => Buffer.from(byte.repeat(31), 'hex');
+const p20 = () => Array.from({ length: 20 }, () => Buffer.from('04'.repeat(32), 'hex'));
 
 class MockBackend implements ProvingBackend {
-  async generateProof(witness: any): Promise<Uint8Array> {
+  async generateProof(_witness: any): Promise<Uint8Array> {
     // Placeholder: production Groth16 payload is 256 bytes (A || B || C)
     return new Uint8Array(256).fill(0xab);
   }
 }
 
+function makeNote(): Note {
+  return new Note(s31('01'), s31('02'), '03'.repeat(32), DEFAULT_DENOMINATION);
+}
+
+function makeMerkleProof(): MerkleProof {
+  return { root: r32, pathElements: p20(), leafIndex: 0 };
+}
+
 describe('Proving Path Abstraction', () => {
-  it('should generate a proof using a mock backend', async () => {
+  it('generates a proof using a mock backend (testOnlyAllowMockHash acknowledges mock-hash mode)', async () => {
     const backend = new MockBackend();
-    
-    const note = new Note(
-      Buffer.from('01'.repeat(31), 'hex'),
-      Buffer.from('02'.repeat(31), 'hex'),
-      '03'.repeat(32), // poolId (hex string)
-      1000n // amount
-    );
-    
-    const merkleProof: MerkleProof = {
-      root: Buffer.from('03'.repeat(32), 'hex'),
-      pathElements: Array.from({ length: 20 }, () => Buffer.from('04'.repeat(32), 'hex')),
-      leafIndex: 0,
-    };
-    
-    const request = {
-      note,
-      merkleProof,
-      recipient: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-      fee: 0n
-    };
-    
-    const proof = await generateWithdrawalProof(request, backend);
-    
+    const request = { note: makeNote(), merkleProof: makeMerkleProof(), recipient: RECIPIENT, fee: 0n };
+
+    // HASH_MODE: mock — testOnlyAllowMockHash explicitly acknowledges SHA-256 stand-ins
+    const proof = await generateWithdrawalProof(request, backend, {
+      testOnlyAllowMockHash: MOCK_HASH_CONTEXT,
+    });
+
     expect(proof).toBeDefined();
     expect(proof.length).toBe(256);
     expect(proof[0]).toBe(0xab);
   });
 
-  it('should throw if no backend is provided to ProofGenerator (via direct usage)', async () => {
-    const { ProofGenerator } = require('../src/proof');
+  it('throws MOCK_HASH_MODE when generateWithdrawalProof is called without testOnlyAllowMockHash', async () => {
+    const backend = new MockBackend();
+    const request = { note: makeNote(), merkleProof: makeMerkleProof(), recipient: RECIPIENT, fee: 0n };
+
+    // No opt-in: must be rejected to prevent accidental production use of SHA-256 nullifier hashes
+    await expect(generateWithdrawalProof(request, backend)).rejects.toThrow('[ZK-106]');
+
+    let code: string | undefined;
+    try {
+      await generateWithdrawalProof(request, backend);
+    } catch (e: any) {
+      code = (e as ProvingError).code;
+    }
+    expect(code).toBe('MOCK_HASH_MODE');
+  });
+
+  it('throws if no backend is provided to ProofGenerator', async () => {
     const generator = new ProofGenerator();
     await expect(generator.generate({})).rejects.toThrow('Proving backend not configured');
+  });
+
+  it('mock backend is invoked and returns expected bytes when opt-in is set', async () => {
+    const backend = new MockBackend();
+    const witness = await ProofGenerator.prepareWitness(makeNote(), makeMerkleProof(), RECIPIENT);
+    const gen = new ProofGenerator(backend);
+
+    // HASH_MODE: mock
+    const rawProof = await gen.generate(witness, { testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
+    expect(rawProof).toBeInstanceOf(Uint8Array);
+    expect(rawProof[0]).toBe(0xab);
   });
 });

--- a/sdk/test/proof_cache.test.ts
+++ b/sdk/test/proof_cache.test.ts
@@ -1,8 +1,12 @@
 /// <reference types="jest" />
+// HASH_MODE: mock (ZK-106) — uses SHA-256 structural stand-ins via prepareWitness;
+// testOnlyAllowMockHash: MOCK_HASH_CONTEXT is set on all generateWithdrawalProof() calls.
+
 import { Note } from '../src/note';
 import { InMemoryProofCache, MerkleProof, ProofGenerator, ProvingBackend } from '../src/proof';
 import { buildWithdrawalProofCacheKey, generateWithdrawalProof, WithdrawalRequest } from '../src/withdraw';
 import { stableHash32 } from '../src/stable';
+import { MOCK_HASH_CONTEXT } from '../src/hash_mode';
 
 class CountingBackend implements ProvingBackend {
   public calls = 0;
@@ -47,8 +51,9 @@ describe('Withdrawal proof cache', () => {
     const cache = new InMemoryProofCache();
     const request = makeRequest();
 
-    const first = await generateWithdrawalProof(request, backend, { cache });
-    const second = await generateWithdrawalProof(request, backend, { cache });
+    // HASH_MODE: mock
+    const first = await generateWithdrawalProof(request, backend, { cache, testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
+    const second = await generateWithdrawalProof(request, backend, { cache, testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
 
     expect(backend.calls).toBe(1);
     expect(first.equals(second)).toBe(true);
@@ -58,8 +63,9 @@ describe('Withdrawal proof cache', () => {
     const backend = new CountingBackend();
     const request = makeRequest();
 
-    await generateWithdrawalProof(request, backend);
-    await generateWithdrawalProof(request, backend);
+    // HASH_MODE: mock
+    await generateWithdrawalProof(request, backend, { testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
+    await generateWithdrawalProof(request, backend, { testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
 
     expect(backend.calls).toBe(2);
   });
@@ -91,8 +97,9 @@ describe('Withdrawal proof cache', () => {
 
     expect(keyA).not.toBe(keyB);
 
-    await generateWithdrawalProof(firstRequest, backend, { cache });
-    await generateWithdrawalProof(secondRequest, backend, { cache });
+    // HASH_MODE: mock
+    await generateWithdrawalProof(firstRequest, backend, { cache, testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
+    await generateWithdrawalProof(secondRequest, backend, { cache, testOnlyAllowMockHash: MOCK_HASH_CONTEXT });
 
     expect(backend.calls).toBe(2);
   });

--- a/sdk/test/zk_integration.test.ts
+++ b/sdk/test/zk_integration.test.ts
@@ -1,10 +1,14 @@
 /// <reference types="jest" />
+// HASH_MODE: mock (ZK-106) — uses SHA-256 structural stand-ins via prepareWitness;
+// testOnlyAllowMockHash: MOCK_HASH_CONTEXT is set on all generate() / generateWithdrawalProof() calls.
+
 import { createDeposit } from '../src/deposit';
 import { LocalMerkleTree } from '../src/merkle';
 import { Note } from '../src/note';
 import { PreparedWitness, ProofGenerator, ProvingBackend, VerifyingBackend } from '../src/proof';
 import { extractPublicInputs, generateWithdrawalProof, verifyWithdrawalProof } from '../src/withdraw';
 import { stableHash32, stableStringify } from '../src/stable';
+import { MOCK_HASH_CONTEXT } from '../src/hash_mode';
 
 class IntegrationProvingBackend implements ProvingBackend {
   async generateProof(witness: PreparedWitness): Promise<Uint8Array> {
@@ -71,6 +75,7 @@ describe('SDK ZK integration flow', () => {
     const [leafIndex] = tree.insertBatch([deposit.commitment]);
     const merkleProof = tree.generateProof(leafIndex);
 
+    // HASH_MODE: mock — testOnlyAllowMockHash explicitly acknowledges SHA-256 stand-ins
     const proof = await generateWithdrawalProof(
       {
         note,
@@ -79,7 +84,8 @@ describe('SDK ZK integration flow', () => {
         relayer: fixture.relayer,
         fee: fixture.fee
       },
-      new IntegrationProvingBackend()
+      new IntegrationProvingBackend(),
+      { testOnlyAllowMockHash: MOCK_HASH_CONTEXT },
     );
 
     const witness = await ProofGenerator.prepareWitness(
@@ -122,7 +128,8 @@ describe('SDK ZK integration flow', () => {
           relayer: fixture.relayer,
           fee: fixture.fee
         },
-        new IntegrationProvingBackend()
+        new IntegrationProvingBackend(),
+        { testOnlyAllowMockHash: MOCK_HASH_CONTEXT },
       )
     ).rejects.toThrow('fee cannot exceed amount');
   });


### PR DESCRIPTION
## Wave Ticket

Wave Issue Keys: `ZK-106`, `ZK-098`

Linked issues:
- Closes #382 
- Closes #374 

## What Changed

**ZK-106 — Explicit mock-hash / live-hash mode abstraction**

- Added hash_mode.ts with the `HashMode` type (`'mock' | 'live'`), the `MOCK_HASH_CONTEXT` named sentinel constant, and `assertNotMockHashMode` — a runtime guard that throws when a mock-hash witness reaches a production proof-generation path without an explicit opt-in.
- Updated `PreparedWitness` in proof.ts to carry an optional `hashMode?: HashMode` field; `ProofGenerator.generate()` now calls `assertNotMockHashMode` before invoking the backend, blocking accidental SHA-256/Poseidon mixing in production.
- Updated withdraw.ts to thread `testOnlyAllowMockHash` through `generateWithdrawalProof` and into `ProofGenerator.generate()`.
- Re-exported `hash_mode` from index.ts.
- Updated all test files that call `generate()` or `generateWithdrawalProof()` to pass `testOnlyAllowMockHash: MOCK_HASH_CONTEXT` (zk_integration.test.ts, proof_cache.test.ts, proof_abstraction.test.ts, privacy_surface.test.ts).
- Added hash_mode.test.ts with 18 tests covering `HashMode`/`MOCK_HASH_CONTEXT` exports, `assertNotMockHashMode` guard firing and bypass, `PreparedWitness` field presence, and canonical witness stripping before backend invocation.

**ZK-098 — Manifest-aware off-chain verification helper**

- Added offline_verify.ts with `OfflineVerificationFailureCategory` (`'BAD_ARTIFACT' | 'BAD_SCHEMA' | 'BAD_PROOF'`), `OfflineVerificationError` (extends `Error`; exposes `.category` and `.cause`), `OfflineVerifyOptions`, and `verifyWithManifest` — an ordered three-layer pre-verification check:
  1. **BAD_ARTIFACT** — delegates to `assertManifestMatchesNoirArtifacts`; catches bytecode, ABI, circuit-ID, name, and optional path mismatches before any cryptography is attempted.
  2. **BAD_SCHEMA** — rejects raw `string[]` inputs; compares the manifest's `public_input_schema` against `WITHDRAWAL_PUBLIC_INPUT_SCHEMA`.
  3. **BAD_PROOF** — delegates to the injected `VerifyingBackend`; normalises both `false` returns and thrown errors into a stable `BAD_PROOF` failure with `.cause` preserved.
- Re-exported `offline_verify` from index.ts.
- Added offline_verify.test.ts with 17 tests covering the success path, all three failure categories, and `OfflineVerificationError` class invariants.

## Validation

- [x] I linked the ZK ticket keys above.
- [x] I ran `node zk_ticket_check.mjs --issue-key ZK-106` and `--issue-key ZK-098`.
- [x] I ran the derived checks locally for both tickets.
- [x] I updated tests or fixtures when the ticket changed circuit or witness behavior.

Validation output:

```text
ZK-106: Introduce explicit mock-hash versus live-hash modes in SDK ZK helpers
Wave File: zk-wave-2 | Area: testing | Priority: High | Complexity: High
Relevant code: sdk/src/poseidon.ts, sdk/src/encoding.ts, sdk/src/public_inputs.ts,
               sdk/src/proof.ts, sdk/test/
Validation checks:
  (circuits) nargo check --workspace  [SKIP — nargo not installed in this environment]
  (circuits) nargo test --workspace   [SKIP — nargo not installed in this environment]
  (sdk) npm run build                 [PASS]

ZK-098: Add a manifest-aware off-chain verification helper that rejects schema mismatch first
Wave File: zk-wave-2 | Area: prover | Priority: Medium | Complexity: Medium
Relevant code: sdk/src/backends/noir.ts, sdk/src/withdraw.ts, sdk/src/artifacts.ts, sdk/test/
Validation checks:
  (circuits) nargo check --workspace  [SKIP — nargo not installed in this environment]
  (circuits) nargo test --workspace   [SKIP — nargo not installed in this environment]
  (sdk) npm run build                 [PASS]

> @privacylayer/sdk@0.1.0 build
> tsc
BUILD_SUCCESSFUL

sdk/test/hash_mode.test.ts:    Tests: 18 passed, 18 total
sdk/test/offline_verify.test.ts: Tests: 17 passed, 17 total