### PR TITLE
Replaces ad hoc artifact path usage with a centralized helper 

### DIFF
--- a/scripts/zk/abi-drift-check.mjs
+++ b/scripts/zk/abi-drift-check.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+import process from "process";
+
+// --- CONFIG ---
+const ARTIFACT_PATH = path.resolve(
+  "circuits/withdraw/target/withdraw.json"
+);
+
+// You can later replace this with a real import from sdk/src/backends/noir.ts
+// e.g. dynamic import if compiled to JS
+const SDK_WITNESS_SCHEMA = [
+  { name: "recipient", type: "field", visibility: "private" },
+  { name: "amount", type: "field", visibility: "private" },
+  { name: "nullifier", type: "field", visibility: "public" },
+  { name: "root", type: "field", visibility: "public" },
+];
+
+// --- HELPERS ---
+function fail(msg) {
+  console.error(`\n❌ ABI Drift Detected:\n${msg}\n`);
+  process.exit(1);
+}
+
+function normalizeAbi(abi) {
+  return abi.map((item, index) => ({
+    name: item.name,
+    type: item.type,
+    visibility: item.visibility || item.public ? "public" : "private",
+    index,
+  }));
+}
+
+function compareSchemas(abiSchema, sdkSchema) {
+  if (abiSchema.length !== sdkSchema.length) {
+    fail(
+      `Field count mismatch:\nABI: ${abiSchema.length}\nSDK: ${sdkSchema.length}`
+    );
+  }
+
+  for (let i = 0; i < abiSchema.length; i++) {
+    const abiField = abiSchema[i];
+    const sdkField = sdkSchema[i];
+
+    // --- NAME CHECK ---
+    if (abiField.name !== sdkField.name) {
+      fail(
+        `Field name mismatch at index ${i}:\nABI: ${abiField.name}\nSDK: ${sdkField.name}`
+      );
+    }
+
+    // --- TYPE CHECK ---
+    if (abiField.type !== sdkField.type) {
+      fail(
+        `Type mismatch for "${abiField.name}":\nABI: ${abiField.type}\nSDK: ${sdkField.type}`
+      );
+    }
+
+    // --- VISIBILITY CHECK ---
+    if (abiField.visibility !== sdkField.visibility) {
+      fail(
+        `Visibility mismatch for "${abiField.name}":\nABI: ${abiField.visibility}\nSDK: ${sdkField.visibility}`
+      );
+    }
+  }
+}
+
+// --- MAIN ---
+function main() {
+  if (!fs.existsSync(ARTIFACT_PATH)) {
+    fail(`Compiled artifact not found at ${ARTIFACT_PATH}`);
+  }
+
+  const artifact = JSON.parse(fs.readFileSync(ARTIFACT_PATH, "utf-8"));
+
+  if (!artifact.abi || !artifact.abi.parameters) {
+    fail("Invalid Noir artifact: ABI parameters missing");
+  }
+
+  const abiSchema = normalizeAbi(artifact.abi.parameters);
+
+  console.log("🔍 Checking ABI vs SDK witness schema...");
+
+  compareSchemas(abiSchema, SDK_WITNESS_SCHEMA);
+
+  console.log("✅ No ABI drift detected.");
+}
+
+main();

--- a/scripts/zk/artifact-path-enforcer.mjs
+++ b/scripts/zk/artifact-path-enforcer.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+import process from "process";
+
+// ===============================
+// CONFIG
+// ===============================
+const ROOT = process.cwd();
+
+const CONFIG = {
+  circuitsDir: "circuits",
+  targetDir: "target",
+  artifactExt: ".json",
+};
+
+// Files to scan for bad usage
+const SCAN_TARGETS = [
+  "sdk/src",
+  "scripts",
+];
+
+// Allowed helper usage pattern
+const ALLOWED_IMPORT = "artifacts";
+
+// ===============================
+// ARTIFACT PATH HELPER (SOURCE OF TRUTH)
+// ===============================
+export function getArtifactPath({ circuit, version = "latest" }) {
+  if (!circuit) {
+    throw new Error("Missing circuit name for artifact path");
+  }
+
+  // Version abstraction (future-proof)
+  const versionSegment = version === "latest" ? "" : `/${version}`;
+
+  return path.join(
+    ROOT,
+    CONFIG.circuitsDir,
+    circuit,
+    versionSegment,
+    CONFIG.targetDir,
+    `${circuit}${CONFIG.artifactExt}`
+  );
+}
+
+// ===============================
+// VALIDATION: PATH CONSISTENCY
+// ===============================
+function assertValidArtifactPath(p) {
+  if (!p.includes(CONFIG.circuitsDir) || !p.endsWith(CONFIG.artifactExt)) {
+    throw new Error(`Invalid artifact path: ${p}`);
+  }
+}
+
+// ===============================
+// SCAN FOR HARD-CODED PATHS
+// ===============================
+function scanForHardcodedPaths() {
+  console.log("🔍 Scanning for hard-coded artifact paths...");
+
+  const violations = [];
+
+  function walk(dir) {
+    if (!fs.existsSync(dir)) return;
+
+    for (const file of fs.readdirSync(dir)) {
+      const fullPath = path.join(dir, file);
+
+      if (fs.statSync(fullPath).isDirectory()) {
+        walk(fullPath);
+      } else if (file.endsWith(".ts") || file.endsWith(".js") || file.endsWith(".mjs")) {
+        const content = fs.readFileSync(fullPath, "utf-8");
+
+        // Detect raw path usage like "circuits/.../target/...json"
+        const regex = /circuits\/.*\/target\/.*\.json/g;
+
+        const matches = content.match(regex);
+        if (matches) {
+          // Ignore if using helper
+          if (!content.includes(ALLOWED_IMPORT)) {
+            violations.push({
+              file: fullPath,
+              matches,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  SCAN_TARGETS.forEach((dir) => walk(path.join(ROOT, dir)));
+
+  if (violations.length > 0) {
+    console.error("\n❌ Hard-coded artifact paths detected:\n");
+
+    for (const v of violations) {
+      console.error(`File: ${v.file}`);
+      v.matches.forEach((m) => console.error(`  → ${m}`));
+    }
+
+    process.exit(1);
+  }
+
+  console.log("✅ No hard-coded paths found.");
+}
+
+// ===============================
+// REGRESSION TESTS
+// ===============================
+function runRegressionTests() {
+  console.log("🧪 Running artifact path regression tests...");
+
+  const testCases = [
+    {
+      input: { circuit: "withdraw" },
+      expected: path.join(
+        ROOT,
+        "circuits",
+        "withdraw",
+        "target",
+        "withdraw.json"
+      ),
+    },
+    {
+      input: { circuit: "withdraw", version: "v1" },
+      expected: path.join(
+        ROOT,
+        "circuits",
+        "withdraw",
+        "v1",
+        "target",
+        "withdraw.json"
+      ),
+    },
+  ];
+
+  for (const { input, expected } of testCases) {
+    const result = getArtifactPath(input);
+
+    if (result !== expected) {
+      console.error("\n❌ Path regression failure:");
+      console.error("Input:", input);
+      console.error("Expected:", expected);
+      console.error("Got:", result);
+      process.exit(1);
+    }
+
+    assertValidArtifactPath(result);
+  }
+
+  console.log("✅ All regression tests passed.");
+}
+
+// ===============================
+// MAIN
+// ===============================
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--test")) {
+    runRegressionTests();
+    return;
+  }
+
+  scanForHardcodedPaths();
+  runRegressionTests();
+
+  console.log("\n🚀 Artifact path enforcement passed.");
+}
+
+main();


### PR DESCRIPTION
## Wave Ticket

Wave Issue Key: `ZK-___`

Linked issue:
- Closes #366 

## What Changed

- 

## Validation

- [ ] I linked the ZK ticket key above.
- [ ] I ran `node scripts/zk_ticket_check.mjs --issue-key ZK-___`.
- [ ] I ran the derived checks locally for the ticket I am implementing.
- [ ] I updated tests or fixtures when the ticket changed circuit or witness behavior.

Validation output:

```text
paste the command output here
```
